### PR TITLE
Feature | Record responses

### DIFF
--- a/src/Facades/Saloon.php
+++ b/src/Facades/Saloon.php
@@ -13,6 +13,11 @@ use Illuminate\Support\Facades\Facade as BaseFacade;
  * @method assertSentJson(string $request, array $data)
  * @method assertNothingSent()
  * @method assertSentCount(int $count)
+ * @method record()
+ * @method stopRecording()
+ * @method isRecording()
+ * @method getRecordedResponses()
+ * @method getLastRecordedResponse()
  */
 class Saloon extends BaseFacade
 {

--- a/src/Managers/FeatureManager.php
+++ b/src/Managers/FeatureManager.php
@@ -3,9 +3,11 @@
 namespace Sammyjo20\SaloonLaravel\Managers;
 
 use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Http\SaloonResponse;
 use Sammyjo20\Saloon\Managers\LaravelManager;
 use Sammyjo20\SaloonLaravel\Clients\MockClient;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponsesProvidedException;
+use Sammyjo20\SaloonLaravel\Facades\Saloon;
 
 class FeatureManager
 {
@@ -52,6 +54,27 @@ class FeatureManager
         }
 
         $this->laravelManager->setMockClient($mockClient);
+    }
+
+    /**
+     * Boot the recording feature.
+     *
+     * @return void
+     * @throws SaloonNoMockResponsesProvidedException
+     */
+    public function bootRecordingFeature(): void
+    {
+        if (Saloon::isRecording() === false) {
+            return;
+        }
+
+        // Register a response interceptor which will record the response.
+
+        $this->request->addResponseInterceptor(function (SaloonRequest $request, SaloonResponse $response) {
+            Saloon::recordResponse($response);
+
+            return $response;
+        });
     }
 
     /**

--- a/src/Managers/FeatureManager.php
+++ b/src/Managers/FeatureManager.php
@@ -4,10 +4,10 @@ namespace Sammyjo20\SaloonLaravel\Managers;
 
 use Sammyjo20\Saloon\Http\SaloonRequest;
 use Sammyjo20\Saloon\Http\SaloonResponse;
+use Sammyjo20\SaloonLaravel\Facades\Saloon;
 use Sammyjo20\Saloon\Managers\LaravelManager;
 use Sammyjo20\SaloonLaravel\Clients\MockClient;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponsesProvidedException;
-use Sammyjo20\SaloonLaravel\Facades\Saloon;
 
 class FeatureManager
 {

--- a/src/Saloon.php
+++ b/src/Saloon.php
@@ -3,12 +3,27 @@
 namespace Sammyjo20\SaloonLaravel;
 
 use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Http\SaloonResponse;
 use Sammyjo20\Saloon\Managers\LaravelManager;
 use Sammyjo20\SaloonLaravel\Clients\MockClient;
 use Sammyjo20\SaloonLaravel\Managers\FeatureManager;
 
 class Saloon
 {
+    /**
+     * Determines if requests should be recorded.
+     *
+     * @var bool
+     */
+    protected bool $record = false;
+
+    /**
+     * An array of the recorded responses if $record is enabled.
+     *
+     * @var array
+     */
+    protected array $recordedResponses = [];
+
     /**
      * The boot method. This is called by Saloon and from within here, we can push almost anything
      * into Saloon, but most important - we can push interceptors and handlers 🚀
@@ -24,6 +39,7 @@ class Saloon
         $manager = new FeatureManager($laravelManager, $request);
 
         $manager->bootMockingFeature();
+        $manager->bootRecordingFeature();
 
         return $manager->getLaravelManager();
     }
@@ -106,5 +122,74 @@ class Saloon
     public static function assertSentCount(int $count): void
     {
         static::mockClient()->assertSentCount($count);
+    }
+
+    /**
+     * Start Saloon recording responses.
+     *
+     * @return void
+     */
+    public function record(): void
+    {
+        $this->record = true;
+    }
+
+    /**
+     * Stop Saloon recording responses.
+     *
+     * @return void
+     */
+    public function stopRecording(): void
+    {
+        $this->record = false;
+    }
+
+    /**
+     * Check if Saloon is recording
+     *
+     * @return bool
+     */
+    public function isRecording(): bool
+    {
+        return $this->record;
+    }
+
+    /**
+     * Record a response.
+     *
+     * @param SaloonResponse $response
+     * @return void
+     */
+    public function recordResponse(SaloonResponse $response): void
+    {
+        $this->recordedResponses[] = $response;
+    }
+
+    /**
+     * Get all the recorded responses.
+     *
+     * @return array
+     */
+    public function getRecordedResponses(): array
+    {
+        return $this->recordedResponses;
+    }
+
+    /**
+     * Get the last response that Saloon recorded.
+     *
+     * @return SaloonResponse|null
+     */
+    public function getLastRecordedResponse(): ?SaloonResponse
+    {
+        if (empty($this->recordedResponses)) {
+            return null;
+        }
+
+        $lastResponse = end($this->recordedResponses);
+
+        reset($this->recordedResponses);
+
+        return $lastResponse;
     }
 }

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -14,7 +14,7 @@ class SaloonServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        $this->app->bind('saloon', fn () => new Saloon);
+        $this->app->bind('saloon', Saloon::class);
         $this->app->singleton(MockClient::class, fn () => new MockClient);
 
         if ($this->app->runningInConsole()) {

--- a/src/Services/Recorder.php
+++ b/src/Services/Recorder.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Sammyjo20\SaloonLaravel\Services;
-
-class Recorder
-{
-
-}

--- a/src/Services/Recorder.php
+++ b/src/Services/Recorder.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sammyjo20\SaloonLaravel\Services;
+
+class Recorder
+{
+
+}

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -2,13 +2,13 @@
 
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\SaloonLaravel\Facades\Saloon;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\UserRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\ErrorRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Connectors\TestConnector;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\ErrorRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponsesProvidedException;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Connectors\QueryParameterConnector;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\DifferentServiceUserRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\QueryParameterConnectorRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\QueryParameterConnector;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\DifferentServiceUserRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\QueryParameterConnectorRequest;
 
 test('a request can be mocked with a sequence', function () {
     Saloon::fake([

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\ErrorRequest;
 use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\ErrorRequest;
 
 test('a request can be made successfully', function () {
     $request = new UserRequest();

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\UserRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\ErrorRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\ErrorRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
 
 test('a request can be made successfully', function () {
     $request = new UserRequest();

--- a/tests/Feature/ResponseRecorderTest.php
+++ b/tests/Feature/ResponseRecorderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\SaloonLaravel\Facades\Saloon;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
+
+test('you can record a response and you can get the recorded responses', function () {
+    Saloon::fake([
+        MockResponse::make(),
+    ]);
+
+    Saloon::record();
+
+    expect(Saloon::isRecording())->toBeTrue();
+
+    $response = UserRequest::make()->send();
+
+    $recorded = Saloon::getRecordedResponses();
+
+    expect($recorded)->toBeArray();
+    expect($recorded)->toHaveCount(1);
+    expect($recorded[0])->toEqual($response);
+});
+
+test('you can get the last recorded response', function () {
+    Saloon::fake([
+        MockResponse::make(['id' => 1]),
+        MockResponse::make(['id' => 2]),
+    ]);
+
+    Saloon::record();
+
+    expect(Saloon::isRecording())->toBeTrue();
+
+    UserRequest::make()->send();
+    UserRequest::make()->send();
+
+    $recorded = Saloon::getRecordedResponses();
+
+    expect($recorded)->toBeArray();
+    expect($recorded)->toHaveCount(2);
+
+    $lastResponse = Saloon::getLastRecordedResponse();
+
+    expect($lastResponse->json())->toEqual(['id' => 2]);
+});
+
+test('you can stop recording', function () {
+    Saloon::fake([
+        MockResponse::make(['id' => 1]),
+        MockResponse::make(['id' => 2]),
+    ]);
+
+    Saloon::record();
+
+    expect(Saloon::isRecording())->toBeTrue();
+
+    UserRequest::make()->send();
+
+    Saloon::stopRecording();
+
+    expect(Saloon::isRecording())->toBeFalse();
+
+    UserRequest::make()->send();
+
+    $recorded = Saloon::getRecordedResponses();
+
+    expect($recorded)->toBeArray();
+    expect($recorded)->toHaveCount(1);
+
+    $lastResponse = Saloon::getLastRecordedResponse();
+
+    expect($lastResponse->json())->toEqual(['id' => 1]);
+});

--- a/tests/Fixtures/Connectors/DifferentServiceConnector.php
+++ b/tests/Fixtures/Connectors/DifferentServiceConnector.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Sammyjo20\SaloonLaravel\Tests\Resources\Connectors;
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors;
 
 use Sammyjo20\Saloon\Http\SaloonConnector;
 use Sammyjo20\Saloon\Traits\Plugins\AcceptsJson;
 
-class TestConnector extends SaloonConnector
+class DifferentServiceConnector extends SaloonConnector
 {
     use AcceptsJson;
 
@@ -16,7 +16,7 @@ class TestConnector extends SaloonConnector
      */
     public function defineBaseUrl(): string
     {
-        return apiUrl();
+        return 'https://google.com';
     }
 
     /**

--- a/tests/Fixtures/Connectors/QueryParameterConnector.php
+++ b/tests/Fixtures/Connectors/QueryParameterConnector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sammyjo20\SaloonLaravel\Tests\Resources\Connectors;
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors;
 
 use Sammyjo20\Saloon\Http\SaloonConnector;
 use Sammyjo20\Saloon\Traits\Plugins\AcceptsJson;

--- a/tests/Fixtures/Connectors/TestConnector.php
+++ b/tests/Fixtures/Connectors/TestConnector.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Sammyjo20\SaloonLaravel\Tests\Resources\Connectors;
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors;
 
 use Sammyjo20\Saloon\Http\SaloonConnector;
 use Sammyjo20\Saloon\Traits\Plugins\AcceptsJson;
 
-class DifferentServiceConnector extends SaloonConnector
+class TestConnector extends SaloonConnector
 {
     use AcceptsJson;
 
@@ -16,7 +16,7 @@ class DifferentServiceConnector extends SaloonConnector
      */
     public function defineBaseUrl(): string
     {
-        return 'https://google.com';
+        return apiUrl();
     }
 
     /**

--- a/tests/Fixtures/Requests/DifferentServiceUserRequest.php
+++ b/tests/Fixtures/Requests/DifferentServiceUserRequest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Sammyjo20\SaloonLaravel\Tests\Resources\Requests;
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests;
 
 use Sammyjo20\Saloon\Constants\Saloon;
 use Sammyjo20\Saloon\Http\SaloonRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Connectors\DifferentServiceConnector;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\DifferentServiceConnector;
 
 class DifferentServiceUserRequest extends SaloonRequest
 {

--- a/tests/Fixtures/Requests/ErrorRequest.php
+++ b/tests/Fixtures/Requests/ErrorRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Sammyjo20\SaloonLaravel\Tests\Resources\Requests;
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests;
 
 use Sammyjo20\Saloon\Constants\Saloon;
 use Sammyjo20\Saloon\Http\SaloonRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Connectors\QueryParameterConnector;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
 
-class QueryParameterConnectorRequest extends SaloonRequest
+class ErrorRequest extends SaloonRequest
 {
     /**
      * Define the method that the request will use.
@@ -20,7 +20,7 @@ class QueryParameterConnectorRequest extends SaloonRequest
      *
      * @var string|null
      */
-    protected ?string $connector = QueryParameterConnector::class;
+    protected ?string $connector = TestConnector::class;
 
     /**
      * Define the endpoint for the request.
@@ -29,13 +29,6 @@ class QueryParameterConnectorRequest extends SaloonRequest
      */
     public function defineEndpoint(): string
     {
-        return '/user';
-    }
-
-    public function defaultQuery(): array
-    {
-        return [
-            'include' => 'user',
-        ];
+        return '/error';
     }
 }

--- a/tests/Fixtures/Requests/QueryParameterConnectorRequest.php
+++ b/tests/Fixtures/Requests/QueryParameterConnectorRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Sammyjo20\SaloonLaravel\Tests\Resources\Requests;
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests;
 
 use Sammyjo20\Saloon\Constants\Saloon;
 use Sammyjo20\Saloon\Http\SaloonRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Connectors\TestConnector;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\QueryParameterConnector;
 
-class UserRequest extends SaloonRequest
+class QueryParameterConnectorRequest extends SaloonRequest
 {
     /**
      * Define the method that the request will use.
@@ -20,7 +20,7 @@ class UserRequest extends SaloonRequest
      *
      * @var string|null
      */
-    protected ?string $connector = TestConnector::class;
+    protected ?string $connector = QueryParameterConnector::class;
 
     /**
      * Define the endpoint for the request.
@@ -30,5 +30,12 @@ class UserRequest extends SaloonRequest
     public function defineEndpoint(): string
     {
         return '/user';
+    }
+
+    public function defaultQuery(): array
+    {
+        return [
+            'include' => 'user',
+        ];
     }
 }

--- a/tests/Fixtures/Requests/UserRequest.php
+++ b/tests/Fixtures/Requests/UserRequest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Sammyjo20\SaloonLaravel\Tests\Resources\Requests;
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests;
 
 use Sammyjo20\Saloon\Constants\Saloon;
 use Sammyjo20\Saloon\Http\SaloonRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Connectors\TestConnector;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
 
-class ErrorRequest extends SaloonRequest
+class UserRequest extends SaloonRequest
 {
     /**
      * Define the method that the request will use.
@@ -29,6 +29,6 @@ class ErrorRequest extends SaloonRequest
      */
     public function defineEndpoint(): string
     {
-        return '/error';
+        return '/user';
     }
 }

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -5,8 +5,8 @@ use Sammyjo20\Saloon\Http\SaloonRequest;
 use Sammyjo20\Saloon\Http\SaloonResponse;
 use GuzzleHttp\Exception\ConnectException;
 use Sammyjo20\SaloonLaravel\Facades\Saloon;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\UserRequest;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\ErrorRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\ErrorRequest;
 
 test('that assertSent works with a request', function () {
     Saloon::fake([

--- a/tests/Unit/RequestManagerTest.php
+++ b/tests/Unit/RequestManagerTest.php
@@ -4,7 +4,7 @@ use Sammyjo20\SaloonLaravel\Saloon;
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\Saloon\Managers\RequestManager;
-use Sammyjo20\SaloonLaravel\Tests\Resources\Requests\UserRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
 use Sammyjo20\Saloon\Exceptions\SaloonMultipleMockMethodsException;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponsesProvidedException;
 


### PR DESCRIPTION
This PR introduces the ability for Saloon to record responses in Laravel. It will use the service container.

```php
use Sammyjo20\SaloonLaravel\Facades\Saloon;

Saloon::record();
Saloon::isRecording();
Saloon::getRecordedResponses();
Saloon::getLastRecordedResponse();
Saloon::stopRecording();
```