### PR TITLE
Feature | Added a new encrypted cast

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,8 @@
             <directory suffix=".php">./src</directory>
         </include>
     </coverage>
+    <php>
+        <env name="APP_KEY" value="base64:g6rX3ygsFZiO446CYsmZVbPZBGavoH0sVbGXZbS03SI="/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+    </php>
 </phpunit>

--- a/src/Casts/EncryptedOAuthAuthenticatorCast.php
+++ b/src/Casts/EncryptedOAuthAuthenticatorCast.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Sammyjo20\SaloonLaravel\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use InvalidArgumentException;
+use Sammyjo20\Saloon\Interfaces\OAuthAuthenticatorInterface;
+
+class EncryptedOAuthAuthenticatorCast implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param $model
+     * @param string $key
+     * @param $value
+     * @param array $attributes
+     * @return OAuthAuthenticatorInterface|null
+     */
+    public function get($model, string $key, $value, array $attributes): ?OAuthAuthenticatorInterface
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        return unserialize(decrypt($value), ['allowed_classes' => true]);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param $model
+     * @param string $key
+     * @param $value
+     * @param array $attributes
+     * @return mixed|void
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (! $value instanceof OAuthAuthenticatorInterface) {
+            throw new InvalidArgumentException('The given value is not an OAuthAuthenticatorInterface instance.');
+        }
+
+        return encrypt(serialize($value));
+    }
+}

--- a/tests/Feature/EncryptedOAuthAuthenticatorCastTest.php
+++ b/tests/Feature/EncryptedOAuthAuthenticatorCastTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Sammyjo20\Saloon\Http\Auth\AccessTokenAuthenticator;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Models\EncryptedOAuthModel;
+
+test('the authenticator can be encrypted, serialized and decrypted and unserialized when using the cast', function () {
+    $model = new EncryptedOAuthModel();
+    $authenticator = new AccessTokenAuthenticator('access', 'refresh', now());
+
+    $model->auth = $authenticator;
+
+    $rawAuth = $model->getAttributes()['auth'];
+
+    expect($rawAuth)->toBeString();
+    expect(decrypt($rawAuth))->toEqual(serialize($authenticator));
+
+    // Now lets try to use the accessor
+
+    $modelAuth = $model->auth;
+
+    expect($modelAuth)->toEqual($authenticator);
+});
+
+test('the cast will accept null', function () {
+    $model = new EncryptedOAuthModel();
+    $model->auth = null;
+
+    expect($model->auth)->toBeNull();
+});
+
+test('it will throw an exception if you pass in a value that is not null', function () {
+    $model = new EncryptedOAuthModel();
+    $model->auth = 'Hello';
+})->throws(InvalidArgumentException::class, 'The given value is not an OAuthAuthenticatorInterface instance.');

--- a/tests/Fixtures/Models/EncryptedOAuthModel.php
+++ b/tests/Fixtures/Models/EncryptedOAuthModel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model as BaseModel;
+use Sammyjo20\SaloonLaravel\Casts\EncryptedOAuthAuthenticatorCast;
+use Sammyjo20\SaloonLaravel\Casts\OAuthAuthenticatorCast;
+
+class EncryptedOAuthModel extends BaseModel
+{
+    protected $casts = [
+        'auth' => EncryptedOAuthAuthenticatorCast::class,
+    ];
+}


### PR DESCRIPTION
This adds an encrypted version of the `OAuthAuthenticatorCast`. This means that it will be encrypted and decrypted when using the cast, because you should always encrypt the OAuth2 authentication.