### PR TITLE
Feature | Record Requests In Telescope

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1]
+        php: [8.0, 8.1]
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,10 @@ jobs:
         include:
           - laravel: 8.*
             testbench: ^6.24
+            telescope: ~4.6
           - laravel: 9.*
             testbench: 7.*
+            telescope: ^4.9
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -47,7 +49,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "laravel/telescope:${{ matrix.telescope }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [8.*, 9.*]
+        laravel: [^8.83, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: ^8.83

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
         laravel: [8.*, 9.*]
-        stability: [prefer-stable]
+        stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: ^6.24

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         laravel: [8.*, 9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
+          - laravel: ^8.83
             testbench: ^6.24
             telescope: ~4.6
           - laravel: 9.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1]
-        laravel: [^8.83, 9.*]
-        stability: [prefer-lowest, prefer-stable]
+        laravel: [8.*, 9.*]
+        stability: [prefer-stable]
         include:
-          - laravel: ^8.83
+          - laravel: 8.*
             testbench: ^6.24
             telescope: ~4.6
           - laravel: 9.*

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/console": "^8.0 || ^9.0",
-        "illuminate/support": "^8.0 || ^9.0",
+        "illuminate/support": "^8.37 || ^9.0",
         "sammyjo20/saloon": "^1.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
-        "laravel/telescope": "~4.6 || ^4.9",
+        "laravel/telescope": "^4.6 || ^4.9",
         "orchestra/testbench": "^6.24 || ^7.8",
         "pestphp/pest": "^1.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
+        "laravel/telescope": "^4.9",
         "orchestra/testbench": "^v6.24.0",
         "pestphp/pest": "^1.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
-        "laravel/telescope": "^4.6 || ^4.9",
+        "laravel/telescope": "~4.6 || ^4.9",
         "orchestra/testbench": "^6.24 || ^7.8",
         "pestphp/pest": "^1.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
-        "laravel/telescope": "^4.9",
+        "laravel/telescope": "^4.6 || ^4.9",
         "orchestra/testbench": "^6.24 || ^7.8",
         "pestphp/pest": "^1.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     "homepage": "https://github.com/sammyjo20/saloon-laravel",
     "require": {
         "php": "^8.0",
-        "illuminate/console": "^8.0 || ^9.0",
-        "illuminate/support": "^8.0 || ^9.0",
+        "illuminate/console": "^8.37 || ^9.0",
+        "illuminate/support": "^8.37 || ^9.0",
         "sammyjo20/saloon": "^1.5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.12",
         "laravel/telescope": "^4.6",
-        "orchestra/testbench": "^6.24 || ^7.8",
-        "pestphp/pest": "^1.21"
+        "orchestra/testbench": "^6.24 || ^7.11",
+        "pestphp/pest": "^1.22.1"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     "require": {
         "php": "^8.0",
         "illuminate/console": "^8.0 || ^9.0",
-        "illuminate/support": "^8.37 || ^9.0",
+        "illuminate/support": "^8.0 || ^9.0",
         "sammyjo20/saloon": "^1.5"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.5",
-        "laravel/telescope": "^4.6 || ^4.9",
+        "friendsofphp/php-cs-fixer": "^3.12",
+        "laravel/telescope": "^4.6",
         "orchestra/testbench": "^6.24 || ^7.8",
         "pestphp/pest": "^1.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
         "laravel/telescope": "^4.9",
-        "orchestra/testbench": "^6.24 || ^7.7",
+        "orchestra/testbench": "^6.24 || ^7.8",
         "pestphp/pest": "^1.21"
     },
     "minimum-stability": "stable",
@@ -69,5 +69,8 @@
         "test": [
             "./vendor/bin/pest"
         ]
+    },
+    "suggest": {
+        "laravel/telescope": "Required to record requests on Laravel Telescope"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,7 +18,7 @@
     <php>
         <env name="APP_KEY" value="base64:g6rX3ygsFZiO446CYsmZVbPZBGavoH0sVbGXZbS03SI="/>
         <env name="BCRYPT_ROUNDS" value="4"/>
-         <env name="DB_CONNECTION" value="sqlite"/>
-         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,5 +18,7 @@
     <php>
         <env name="APP_KEY" value="base64:g6rX3ygsFZiO446CYsmZVbPZBGavoH0sVbGXZbS03SI="/>
         <env name="BCRYPT_ROUNDS" value="4"/>
+         <env name="DB_CONNECTION" value="sqlite"/>
+         <env name="DB_DATABASE" value=":memory:"/>
     </php>
 </phpunit>

--- a/src/Listeners/RecordSaloonToTelescope.php
+++ b/src/Listeners/RecordSaloonToTelescope.php
@@ -2,9 +2,9 @@
 
 namespace Sammyjo20\SaloonLaravel\Listeners;
 
-use Illuminate\Support\Str;
 use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
+use Sammyjo20\Saloon\Http\SaloonRequest;
 use Sammyjo20\SaloonLaravel\Events\SentSaloonRequest;
 
 class RecordSaloonToTelescope
@@ -25,20 +25,19 @@ class RecordSaloonToTelescope
 
         // We'll attempt to guess if the response is JSON.
 
-        $responseIsJson = Str::of($response->header('Content-Type'))->lower()->contains('application/json');
+        $isJsonResponse = (bool)json_decode($response->body(), true);
 
         // Let's now append any query parameters to the end of the URL, since Saloon's getFullRequestUrl
         // does not provide it.
 
-        $url = $request->getFullRequestUrl();
-        $glue = str_contains($url, '?') ? '&' : '?';
-        $query = http_build_query($request->getQuery());
-
-        $fullUrl = empty($query) ? $url : ($url . $glue . $query);
+        $fullUrl = $this->buildFullUrl($request);
 
         // We'll now record the client request!
 
         $telescope = app()->make(Telescope::class);
+
+        $connectorClass = get_class($request->getConnector());
+        $requestClass = get_class($request);
 
         $entry = IncomingEntry::make([
             'method' => $request->getMethod(),
@@ -47,17 +46,36 @@ class RecordSaloonToTelescope
             'payload' => $request->getData(),
             'response_status' => $response->status(),
             'response_headers' => $response->headers(),
-            'response' => $responseIsJson ? $response->json() : $response->body(),
-            'saloon_connector' => get_class($request->getConnector()),
-            'saloon_request' => get_class($request),
+            'response' => $isJsonResponse ? $response->json() : $response->body(),
+            'saloon_connector' => $connectorClass,
+            'saloon_request' => $requestClass,
         ]);
+
+        // Create tags
 
         $entry->tags([
             'Saloon',
-            'SaloonConnector:' . get_class($request->getConnector()),
-            'SaloonRequest:' . get_class($request),
+            'SaloonConnector:' . $connectorClass,
+            'SaloonRequest:' . $requestClass,
         ]);
 
         $telescope->recordClientRequest($entry);
+    }
+
+    /**
+     * Build the full URL with query parameters
+     *
+     * @param SaloonRequest $request
+     * @return string
+     * @throws \ReflectionException
+     * @throws \Sammyjo20\Saloon\Exceptions\SaloonInvalidConnectorException
+     */
+    private function buildFullUrl(SaloonRequest $request): string
+    {
+        $url = $request->getFullRequestUrl();
+        $glue = str_contains($url, '?') ? '&' : '?';
+        $query = http_build_query($request->getQuery());
+
+        return empty($query) ? $url : ($url . $glue . $query);
     }
 }

--- a/src/Listeners/RecordSaloonToTelescope.php
+++ b/src/Listeners/RecordSaloonToTelescope.php
@@ -2,8 +2,8 @@
 
 namespace Sammyjo20\SaloonLaravel\Listeners;
 
-use Laravel\Telescope\IncomingEntry;
 use Laravel\Telescope\Telescope;
+use Laravel\Telescope\IncomingEntry;
 use Sammyjo20\Saloon\Http\SaloonRequest;
 use Sammyjo20\SaloonLaravel\Events\SentSaloonRequest;
 

--- a/src/Listeners/RecordSaloonToTelescope.php
+++ b/src/Listeners/RecordSaloonToTelescope.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Sammyjo20\SaloonLaravel\Listeners;
+
+use Illuminate\Support\Str;
+use Laravel\Telescope\IncomingEntry;
+use Laravel\Telescope\Telescope;
+use Sammyjo20\SaloonLaravel\Events\SentSaloonRequest;
+
+class RecordSaloonToTelescope
+{
+    /**
+     * Handle the event.
+     *
+     * @param SentSaloonRequest $event
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \ReflectionException
+     * @throws \Sammyjo20\Saloon\Exceptions\SaloonInvalidConnectorException
+     */
+    public function handle(SentSaloonRequest $event): void
+    {
+        $request = $event->request;
+        $response = $event->response;
+
+        // We'll attempt to guess if the response is JSON.
+
+        $responseIsJson = Str::of($response->header('Content-Type'))->lower()->contains('application/json');
+
+        // Let's now append any query parameters to the end of the URL, since Saloon's getFullRequestUrl
+        // does not provide it.
+
+        $url = $request->getFullRequestUrl();
+        $glue = str_contains($url, '?') ? '&' : '?';
+        $query = http_build_query($request->getQuery());
+
+        $fullUrl = empty($query) ? $url : ($url . $glue . $query);
+
+        // We'll now record the client request!
+
+        $telescope = app()->make(Telescope::class);
+
+        $entry = IncomingEntry::make([
+            'method' => $request->getMethod(),
+            'uri' => $fullUrl,
+            'headers' => $request->getHeaders(),
+            'payload' => $request->getData(),
+            'response_status' => $response->status(),
+            'response_headers' => $response->headers(),
+            'response' => $responseIsJson ? $response->json() : $response->body(),
+            'saloon_connector' => get_class($request->getConnector()),
+            'saloon_request' => get_class($request),
+        ]);
+
+        $entry->tags([
+            'Saloon',
+            'SaloonConnector:' . get_class($request->getConnector()),
+            'SaloonRequest:' . get_class($request),
+        ]);
+
+        $telescope->recordClientRequest($entry);
+    }
+}

--- a/tests/Feature/TelescopeRecorderTest.php
+++ b/tests/Feature/TelescopeRecorderTest.php
@@ -1,13 +1,16 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Laravel\Telescope\EntryType;
+use Laravel\Telescope\ExtractTags;
 use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\SaloonLaravel\Events\SentSaloonRequest;
 use Sammyjo20\SaloonLaravel\Listeners\RecordSaloonToTelescope;
 use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
 use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\PostRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
 
 beforeEach(function () {
     Event::listen(SentSaloonRequest::class, RecordSaloonToTelescope::class);
@@ -29,13 +32,11 @@ test('when a request is made - it is reported to telescope', function () {
     $entry = $entries->sole();
     $entryContent = $entry->content;
 
-    // Make sure all fields are present and it's stored correctly.
-
-    dd($entry);
+    // Make sure all fields are present, and it's stored correctly.
 
     expect($entryContent)->toBeArray();
     expect($entryContent)->toHaveKey('method', 'POST');
-    expect($entryContent)->toHaveKey('uri', 'https://tests.saloon.dev/api/post');
+    expect($entryContent)->toHaveKey('uri', 'https://tests.saloon.dev/api/post?test_query=hello');
     expect($entryContent)->toHaveKey('headers', ['X-Foo' => 'Bar']);
     expect($entryContent)->toHaveKey('payload', ['name' => 'Sammy']);
     expect($entryContent)->toHaveKey('response_status', 200);
@@ -43,12 +44,31 @@ test('when a request is made - it is reported to telescope', function () {
     expect($entryContent)->toHaveKey('response', ['name' => 'Sammy']);
     expect($entryContent)->toHaveKey('saloon_connector', TestConnector::class);
     expect($entryContent)->toHaveKey('saloon_request', PostRequest::class);
+
+    // Now we need to check the tags
+
+    $tags = DB::table('telescope_entries_tags')->get();
+
+    expect($tags)->toHaveCount(3);
+
+    $saloonTag = $tags->where('tag', 'Saloon')->first();
+    $requestTag = $tags->where('tag', 'SaloonRequest:' . PostRequest::class)->first();
+    $connectorTag = $tags->where('tag', 'SaloonConnector:' . TestConnector::class)->first();
+
+    expect($saloonTag)->not()->toBeNull();
+    expect($requestTag)->not()->toBeNull();
+    expect($connectorTag)->not()->toBeNull();
 });
 
-test('query parameters are shown in the url of the telescope report', function () {
+test('it will format the response data as json if it can determine the response is JSON', function () {
+    $mockClient = new MockClient([
+        MockResponse::make('Plain Text Response', 200, ['Content-Type' => 'text/plain'])
+    ]);
 
-});
+    UserRequest::make()->send($mockClient);
 
-test('it will format the response data as json if it can find the correct content type header', function () {
-    // Test it won't format without.
+    $entry = $this->loadTelescopeEntries()->where('type', EntryType::CLIENT_REQUEST)->sole();
+    $entryContent = $entry->content;
+
+    expect($entryContent)->toHaveKey('response', 'Plain Text Response');
 });

--- a/tests/Feature/TelescopeRecorderTest.php
+++ b/tests/Feature/TelescopeRecorderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Laravel\Telescope\EntryType;
+use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\SaloonLaravel\Events\SentSaloonRequest;
+use Sammyjo20\SaloonLaravel\Listeners\RecordSaloonToTelescope;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\PostRequest;
+
+beforeEach(function () {
+    Event::listen(SentSaloonRequest::class, RecordSaloonToTelescope::class);
+});
+
+test('when a request is made - it is reported to telescope', function () {
+    $request = new PostRequest;
+
+    $mockClient = new MockClient([
+        MockResponse::fromRequest($request),
+    ]);
+
+    $request->send($mockClient);
+
+    $entries = $this->loadTelescopeEntries()->where('type', EntryType::CLIENT_REQUEST);
+
+    expect($entries)->toHaveCount(1);
+
+    $entry = $entries->sole();
+    $entryContent = $entry->content;
+
+    // Make sure all fields are present and it's stored correctly.
+
+    dd($entry);
+
+    expect($entryContent)->toBeArray();
+    expect($entryContent)->toHaveKey('method', 'POST');
+    expect($entryContent)->toHaveKey('uri', 'https://tests.saloon.dev/api/post');
+    expect($entryContent)->toHaveKey('headers', ['X-Foo' => 'Bar']);
+    expect($entryContent)->toHaveKey('payload', ['name' => 'Sammy']);
+    expect($entryContent)->toHaveKey('response_status', 200);
+    expect($entryContent)->toHaveKey('response_headers', ['Content-Type' => [0 => 'application/json'], 'X-Foo' => [0 => 'Bar']]);
+    expect($entryContent)->toHaveKey('response', ['name' => 'Sammy']);
+    expect($entryContent)->toHaveKey('saloon_connector', TestConnector::class);
+    expect($entryContent)->toHaveKey('saloon_request', PostRequest::class);
+});
+
+test('query parameters are shown in the url of the telescope report', function () {
+
+});
+
+test('it will format the response data as json if it can find the correct content type header', function () {
+    // Test it won't format without.
+});

--- a/tests/Feature/TelescopeRecorderTest.php
+++ b/tests/Feature/TelescopeRecorderTest.php
@@ -1,16 +1,15 @@
 <?php
 
+use Laravel\Telescope\EntryType;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
-use Laravel\Telescope\EntryType;
-use Laravel\Telescope\ExtractTags;
-use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\SaloonLaravel\Events\SentSaloonRequest;
 use Sammyjo20\SaloonLaravel\Listeners\RecordSaloonToTelescope;
-use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
 use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\PostRequest;
 use Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests\UserRequest;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
 
 beforeEach(function () {
     Event::listen(SentSaloonRequest::class, RecordSaloonToTelescope::class);
@@ -62,7 +61,7 @@ test('when a request is made - it is reported to telescope', function () {
 
 test('it will format the response data as json if it can determine the response is JSON', function () {
     $mockClient = new MockClient([
-        MockResponse::make('Plain Text Response', 200, ['Content-Type' => 'text/plain'])
+        MockResponse::make('Plain Text Response', 200, ['Content-Type' => 'text/plain']),
     ]);
 
     UserRequest::make()->send($mockClient);

--- a/tests/Fixtures/Requests/PostRequest.php
+++ b/tests/Fixtures/Requests/PostRequest.php
@@ -53,4 +53,11 @@ class PostRequest extends SaloonRequest
             'X-Foo' => 'Bar',
         ];
     }
+
+    public function defaultQuery(): array
+    {
+        return [
+            'test_query' => 'hello',
+        ];
+    }
 }

--- a/tests/Fixtures/Requests/PostRequest.php
+++ b/tests/Fixtures/Requests/PostRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sammyjo20\SaloonLaravel\Tests\Fixtures\Requests;
+
+use Sammyjo20\Saloon\Constants\Saloon;
+use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Traits\Plugins\HasJsonBody;
+use Sammyjo20\SaloonLaravel\Tests\Fixtures\Connectors\TestConnector;
+
+class PostRequest extends SaloonRequest
+{
+    use HasJsonBody;
+
+    /**
+     * Define the method that the request will use.
+     *
+     * @var string|null
+     */
+    protected ?string $method = Saloon::POST;
+
+    /**
+     * The connector.
+     *
+     * @var string|null
+     */
+    protected ?string $connector = TestConnector::class;
+
+    /**
+     * Define the endpoint for the request.
+     *
+     * @return string
+     */
+    public function defineEndpoint(): string
+    {
+        return '/post';
+    }
+
+    /**
+     * Default Data
+     *
+     * @return string[]
+     */
+    public function defaultData(): array
+    {
+        return [
+            'name' => 'Sammy',
+        ];
+    }
+
+    public function defaultHeaders(): array
+    {
+        return [
+            'X-Foo' => 'Bar',
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,13 +2,13 @@
 
 namespace Sammyjo20\SaloonLaravel\Tests;
 
-use Illuminate\Support\Collection;
-use Laravel\Telescope\Contracts\EntriesRepository;
-use Laravel\Telescope\Storage\EntryModel;
 use Laravel\Telescope\Telescope;
-use Laravel\Telescope\TelescopeServiceProvider;
+use Illuminate\Support\Collection;
+use Laravel\Telescope\Storage\EntryModel;
 use Sammyjo20\SaloonLaravel\Facades\Saloon;
+use Laravel\Telescope\TelescopeServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Laravel\Telescope\Contracts\EntriesRepository;
 use Sammyjo20\SaloonLaravel\SaloonServiceProvider;
 
 class TestCase extends BaseTestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,8 @@ class TestCase extends BaseTestCase
     protected function defineDatabaseMigrations()
     {
         $this->loadMigrationsFrom(__DIR__ . '/../vendor/laravel/telescope/database/migrations');
+
+        $this->artisan('migrate');
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,11 @@
 
 namespace Sammyjo20\SaloonLaravel\Tests;
 
+use Illuminate\Support\Collection;
+use Laravel\Telescope\Contracts\EntriesRepository;
+use Laravel\Telescope\Storage\EntryModel;
+use Laravel\Telescope\Telescope;
+use Laravel\Telescope\TelescopeServiceProvider;
 use Sammyjo20\SaloonLaravel\Facades\Saloon;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Sammyjo20\SaloonLaravel\SaloonServiceProvider;
@@ -12,7 +17,18 @@ class TestCase extends BaseTestCase
     {
         return [
             SaloonServiceProvider::class,
+            TelescopeServiceProvider::class,
         ];
+    }
+
+    /**
+     * Define database migrations.
+     *
+     * @return void
+     */
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/../vendor/laravel/telescope/database/migrations');
     }
 
     /**
@@ -27,5 +43,17 @@ class TestCase extends BaseTestCase
         return [
             'Saloon' => Saloon::class,
         ];
+    }
+
+    /**
+     * Load the Telescope entries.
+     *
+     * @return Collection
+     */
+    protected function loadTelescopeEntries(): Collection
+    {
+        Telescope::store(app(EntriesRepository::class));
+
+        return EntryModel::all();
     }
 }


### PR DESCRIPTION
This PR introduces a new listener which can be subscribed to so that it records requests in Laravel Telescope. The telescope entry will be recorded under the "HTTP Client" section of Telescope. 

Fixes #21 