### PR TITLE
Fix | Saloon facade alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "extra": {
         "laravel": {
             "aliases": {
-                "Saloon": "Saloon"
+                "Saloon": "Sammyjo20\\SaloonLaravel\\Facades\\Saloon"
             },
             "providers": [
                 "Sammyjo20\\SaloonLaravel\\SaloonServiceProvider"


### PR DESCRIPTION
This PR changes the alias for the Saloon facade to use the proper PSR-4 namespace.

Fixes #27 