### PR TITLE
Update alias and providers namespaces for v2 vendor/package namespace change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,10 +50,10 @@
     "extra": {
         "laravel": {
             "aliases": {
-                "Saloon": "Sammyjo20\\SaloonLaravel\\Facades\\Saloon"
+                "Saloon": "Saloon\\Laravel\\Facades\\Saloon"
             },
             "providers": [
-                "Sammyjo20\\SaloonLaravel\\SaloonServiceProvider"
+                "Saloon\\Laravel\\SaloonServiceProvider"
             ]
         }
     },


### PR DESCRIPTION
The extra.laravel.aliases and the only entry in extra.providers were using the old vendor and package namespaces.
This caused things in Laravel that [auto]loads service providers to fail.