### PR TITLE
Feature | V2 Handling simulated responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/console": "^8.0 || ^9.0",
         "illuminate/http": "^8.0 || ^9.0",
         "illuminate/support": "^8.0 || ^9.0",
-        "sammyjo20/saloon": "2.0.0-beta2"
+        "sammyjo20/saloon": "2.0.0-beta3"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",

--- a/src/Http/Middleware/FrameworkMiddleware.php
+++ b/src/Http/Middleware/FrameworkMiddleware.php
@@ -51,6 +51,10 @@ class FrameworkMiddleware implements RequestMiddleware
             return $this;
         }
 
+        if ($pendingRequest->hasSimulatedResponsePayload()) {
+            return $this;
+        }
+
         if ($mockClient->isEmpty()) {
             throw new NoMockResponseFoundException;
         }

--- a/tests/Feature/SimulatedResponsePayloadTest.php
+++ b/tests/Feature/SimulatedResponsePayloadTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Faking\MockResponse;
 use Saloon\Laravel\Facades\Saloon;
+use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\Faking\SimulatedResponsePayload;
-use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
 
 test('if a simulated response payload was provided before mock response it will take priority', function () {
     Saloon::fake([

--- a/tests/Feature/SimulatedResponsePayloadTest.php
+++ b/tests/Feature/SimulatedResponsePayloadTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Laravel\Facades\Saloon;
+use Saloon\Http\Faking\SimulatedResponsePayload;
+use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
+
+test('if a simulated response payload was provided before mock response it will take priority', function () {
+    Saloon::fake([
+        new MockResponse(['name' => 'Sam'], 200, ['X-Greeting' => 'Howdy']),
+    ]);
+
+    $fakeResponse = new SimulatedResponsePayload(['name' => 'Gareth'], 201, ['X-Greeting' => 'Hello']);
+
+    $request = new UserRequest;
+    $request->middleware()->onRequest(fn () => $fakeResponse);
+
+    $response = TestConnector::make()->send($request);
+
+    expect($response->json())->toEqual(['name' => 'Gareth']);
+    expect($response->status())->toEqual(201);
+    expect($response->header('X-Greeting'))->toEqual('Hello');
+});


### PR DESCRIPTION
This PR makes a change to the mocking logic. If another SimulatedResponsePayload has already been set on the PendingRequest, the MockClient will be ignored.