### PR TITLE
Feature | Add Laravel 10 Support

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -18,10 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.PHP_CS_FIXER }}
+        uses: actions/checkout@v3
       - name: Run PHP CS Fixer
         uses: docker://oskarstark/php-cs-fixer-ga
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1, 8.2]
-        laravel: [10.*]
+        laravel: [9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 9.*
+            testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1, 8.2]
-        laravel: [9.*]
+        laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: 10.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     "homepage": "https://github.com/sammyjo20/saloon-laravel",
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^8.0 || ^9.0",
-        "illuminate/http": "^8.0 || ^9.0",
-        "illuminate/support": "^8.0 || ^9.0",
+        "illuminate/console": "^10.0",
+        "illuminate/http": "^10.0",
+        "illuminate/support": "^10.0",
         "sammyjo20/saloon": "2.0.0-beta6"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
-        "orchestra/testbench": "^6.24 || ^7.7",
+        "orchestra/testbench": "^8.0",
         "pestphp/pest": "^1.21"
     },
     "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
     "homepage": "https://github.com/sammyjo20/saloon-laravel",
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^10.0",
-        "illuminate/http": "^10.0",
-        "illuminate/support": "^10.0",
+        "illuminate/console": "^9.0 || ^10.0",
+        "illuminate/http": "^9.0 || ^10.0",
+        "illuminate/support": "^9.0 || ^10.0",
         "sammyjo20/saloon": "2.0.0-beta6"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^7.7 || ^8.0",
         "pestphp/pest": "^1.21"
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
This PR proposes for v2 to drop support for Laravel 9 but instead offer support for Laravel 10+.