### PR TITLE
Add saloon:list command

### DIFF
--- a/config/saloon.php
+++ b/config/saloon.php
@@ -20,4 +20,18 @@ return [
 
     'default_sender' => GuzzleSender::class,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Integrations Path
+    |--------------------------------------------------------------------------
+    |
+    | By default, this package will create any classes within
+    | /app/Http/Integrations directory. If you're using
+    | a different design approach, then your classes
+    | may be in a different place. You can change
+    | that location so that the saloon:list
+    | command will still find your files
+    |
+    */
+    'integrations_path' => 'App/Http/Integrations',
 ];

--- a/src/Console/Commands/ListCommand.php
+++ b/src/Console/Commands/ListCommand.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Laravel\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ListCommand extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'saloon:list';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'List all Saloon Authenticators, Connectors, Requests, Plugins and Responses';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->newLine();
+
+        $this->components->twoColumnDetail('<fg=green;options=bold>General</>',
+            '<fg=white>Integrations: ' . count($this->getIntegrations()) . '</>'
+        );
+
+        $this->newLine();
+
+        foreach ($this->getIntegrations() as $integration) {
+            $this->getIntegrationOutput($integration);
+
+            foreach ($this->getIntegrationAuthenticators($integration) as $integrationAuthenticator) {
+                $this->getIntegrationAuthenticatorOutput($integrationAuthenticator);
+            }
+
+            foreach ($this->getIntegrationConnectors($integration) as $integrationConnector) {
+                $this->getIntegrationConnectorOutput($integrationConnector);
+            }
+
+            foreach ($this->getIntegrationRequests($integration) as $integrationRequest) {
+                $this->getIntegrationRequestOutput($integrationRequest);
+            }
+
+            foreach ($this->getIntegrationPlugins($integration) as $integrationPlugin) {
+                $this->getIntegrationPluginOutput($integrationPlugin);
+            }
+
+            foreach ($this->getIntegrationResponses($integration) as $integrationResponse) {
+                $this->getIntegrationResponseOutput($integrationResponse);
+            }
+
+            $this->newLine();
+        }
+
+        return Command::SUCCESS;
+    }
+
+
+    protected function getIntegrations(): array
+    {
+        return glob('app/Http/Integrations/*') ?? [];
+    }
+
+    protected function getIntegrationConnectors(string $integration): array
+    {
+        return glob($integration . '/*Connector.php') ?? [];
+    }
+
+    protected function getIntegrationRequests(string $integration): array
+    {
+        return glob($integration . '/Requests/*') ?? [];
+    }
+
+    protected function getIntegrationPlugins(string $integration): array
+    {
+        return glob($integration . '/Plugins/*') ?? [];
+    }
+
+    protected function getIntegrationResponses(string $integration): array
+    {
+        return glob($integration . '/Responses/*') ?? [];
+    }
+
+    protected function getIntegrationAuthenticators(string $integration): array
+    {
+        return glob($integration . '/Auth/*') ?? [];
+    }
+
+    protected function getIntegrationOutput(string $integration)
+    {
+        return $this->components->twoColumnDetail(
+            '<fg=green;options=bold>' . Str::afterLast($integration, '/') . '</>',
+            sprintf(
+                '<fg=white>Connectors: %s / Requests: %s / Plugins: %s / Responses: %s / Authenticators: %s</>',
+                count($this->getIntegrationConnectors($integration)),
+                count($this->getIntegrationRequests($integration)),
+                count($this->getIntegrationPlugins($integration)),
+                count($this->getIntegrationResponses($integration)),
+                count($this->getIntegrationAuthenticators($integration)),
+            )
+        );
+    }
+
+    protected function getIntegrationAuthenticatorOutput(string $authenticator)
+    {
+        return $this->components->twoColumnDetail(
+            '<fg=red>Authenticator</> <fg=gray>...</> ' . Str::afterLast($authenticator, '/')
+        );
+    }
+
+    protected function getIntegrationConnectorOutput(string $connector)
+    {
+        return $this->components->twoColumnDetail(
+            '<fg=blue>Connector</> <fg=gray>.......</> ' . Str::afterLast($connector, '/'),
+            '<fg=gray>' . $this->getIntegrationConnectorBaseUrl($connector) . '</>'
+        );
+    }
+
+    protected function getIntegrationRequestOutput(string $request)
+    {
+        $requestMethod = Str::afterLast($this->getIntegrationRequestMethod($request), ':');
+
+        $requestMethodOutputColour = match ($requestMethod) {
+            'GET' => 'blue',
+            'PATCH', 'POST', 'PUT' => 'green',
+            'DELETE' => 'red',
+            default => 'magenta'
+        };
+
+        return $this->components->twoColumnDetail(
+            '<fg=magenta>Request</> <fg=gray>.........</> ' .
+            Str::afterLast($request, '/'),
+            ' <fg=gray>' . $this->getIntegrationRequestEndpoint($request) . '</>' .
+            ' <fg=' . $requestMethodOutputColour . '>' .
+            Str::afterLast($this->getIntegrationRequestMethod($request), ':') . '</> '
+        );
+    }
+
+    protected function getIntegrationPluginOutput(string $plugin)
+    {
+        return $this->components->twoColumnDetail(
+            '<fg=cyan>Plugin</> <fg=gray>..........</> ' . Str::afterLast($plugin, '/')
+        );
+    }
+
+    protected function getIntegrationResponseOutput(string $response)
+    {
+        return $this->components->twoColumnDetail(
+            '<fg=yellow>Response</> <fg=gray>........</> ' . Str::afterLast($response, '/')
+        );
+    }
+
+    protected function getIntegrationRequestMethod(string $request): string
+    {
+        return Str::match('/\$method\s*=\s*(.*?);/', file_get_contents($request));
+    }
+
+    protected function getIntegrationRequestEndpoint(string $request): string
+    {
+        $regex = '/public\s+function\s+resolveEndpoint\(\):\s+string\s*\{\s*return\s+(.*?);/s';
+        $match = Str::match($regex, file_get_contents($request));
+        $matchSegments = explode('/', $match);
+
+        foreach ($matchSegments as $key => $matchSegment) {
+            if (Str::contains($matchSegment, '$this->')) {
+                $matchSegments[$key] = '{' . Str::before(
+                        Str::after(str_replace(' ', '', $matchSegment), '>'),
+                        ".'"
+                    ) . '}';
+            }
+        }
+
+        return str_replace("'", "", implode('/', $matchSegments));
+    }
+
+    protected function getIntegrationConnectorBaseUrl(string $connector): string
+    {
+        $regex = '/public\s+function\s+resolveBaseUrl\(\):\s+string\s*\{\s*return\s+\'(.*?)\';\s*/s';
+        $matches = Str::match($regex, file_get_contents($connector));
+
+        return Str::after($matches, '://');
+    }
+}

--- a/src/Console/Commands/ListCommand.php
+++ b/src/Console/Commands/ListCommand.php
@@ -103,12 +103,12 @@ class ListCommand extends Command
         return $this->components->twoColumnDetail(
             '<fg=green;options=bold>' . Str::afterLast($integration, '/') . '</>',
             sprintf(
-                '<fg=white>Connectors: %s / Requests: %s / Plugins: %s / Responses: %s / Authenticators: %s</>',
+                '<fg=white>Authenticators: %s / Connectors: %s / Requests: %s / Plugins: %s / Responses: %s</>',
+                count($this->getIntegrationAuthenticators($integration)),
                 count($this->getIntegrationConnectors($integration)),
                 count($this->getIntegrationRequests($integration)),
                 count($this->getIntegrationPlugins($integration)),
                 count($this->getIntegrationResponses($integration)),
-                count($this->getIntegrationAuthenticators($integration)),
             )
         );
     }

--- a/src/Console/Commands/ListCommand.php
+++ b/src/Console/Commands/ListCommand.php
@@ -70,7 +70,7 @@ class ListCommand extends Command
 
     protected function getIntegrations(): array
     {
-        return glob('app/Http/Integrations/*') ?? [];
+        return glob(config('saloon.integrations_path').'/*') ?? [];
     }
 
     protected function getIntegrationConnectors(string $integration): array

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -7,6 +7,7 @@ namespace Saloon\Laravel;
 use Saloon\Helpers\Config;
 use Saloon\Contracts\Sender;
 use Illuminate\Support\ServiceProvider;
+use Saloon\Laravel\Console\Commands\ListCommand;
 use Saloon\Laravel\Http\Faking\MockClient;
 use Saloon\Laravel\Console\Commands\MakePlugin;
 use Saloon\Laravel\Console\Commands\MakeRequest;
@@ -68,6 +69,7 @@ class SaloonServiceProvider extends ServiceProvider
             MakeResponse::class,
             MakePlugin::class,
             MakeAuthenticator::class,
+            ListCommand::class,
         ]);
 
         return $this;


### PR DESCRIPTION
Hey 👋 

I thought it would be good if this package had a list command, similar to how you can use `route:list` in Laravel, which shows information about your integrations in your application. This PR adds that, below is an example of the output from a dummy application I created to test this out:

![image](https://github.com/saloonphp/laravel-plugin/assets/7534029/5846ab1c-2746-4553-be51-74f02e1eb46c)

I've kept a similar convention to other list commands, so you'd run `saloon:list` and this would be the output. At a glance, it lets me see:

- The total number of Integrations in my application
- The total number of Connectors, Requests, Plugins, Responses and Authenticators for each Integration
- The Base URL for each Connector
- The Endpoint for each Request, including any params that are needed such as IDs 
- The method type for each Request

Happy to make any changes that you feel would need making to allow this to be included in the package!

🤠 