### PR TITLE
Upgrade | Minimum Laravel 10 For Future Releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.1, 8.2]
-        laravel: [9.*, 10.*]
+        laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
 

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "homepage": "https://github.com/saloonphp/laravel-plugin",
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^9.52 || ^10.0",
-        "illuminate/http": "^9.52 || ^10.0",
-        "illuminate/support": "^9.52 || ^10.0",
+        "illuminate/console": "^10.0",
+        "illuminate/http": "^10.0",
+        "illuminate/support": "^10.0",
         "saloonphp/saloon": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Speaking with @Sammyjo20 about this pre V3 being released and it was decided to hold off on this until _after_ that was released, so people can still upgrade to V3, if they're running an older version of Laravel.

Now that V3 has been in the wild for some time, this PR updates the necessary dependencies so that any new versions of this package, will only run on Laravel 10. I've tested this myself on a Laravel 9 application and get the following:

```
  Problem 1
    - Root composer.json requires saloonphp/laravel-plugin dev-bump-to-laravel-10 -> satisfiable by saloonphp/laravel-plugin[dev-bump-to-laravel-10].
    - saloonphp/laravel-plugin dev-bump-to-laravel-10 requires illuminate/console ^10.0 -> found illuminate/console[v10.0.0, ..., 10.x-dev] but these were not loaded, likely because it conflicts with another require.
```

and then on Laravel 10:
```
- Downloading saloonphp/laravel-plugin (dev-bump-to-laravel-10 b28bff3)
- Upgrading saloonphp/laravel-plugin (v3.0.0 => dev-bump-to-laravel-10 b28bff3): Extracting archive
- Generating optimized autoload files
```

