### PR TITLE
Feature | V3 - Deprecated MockClient, use Global Mock Client

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,30 @@
+name: PHPStan
+
+on:
+  push:
+    branches:
+      - 'v1'
+      - 'v2'
+      - 'v3'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  phpstan:
+    name: phpstan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Run PHPStan
+        run: ./vendor/bin/phpstan analyse --error-format=github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         laravel: [10.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "name": "saloonphp/laravel-plugin",
-    "description": "Laravel plugin for Saloon",
+    "description": "The official Laravel plugin for Saloon",
     "license": "MIT",
     "type": "library",
     "keywords": [
-        "sammyjo20",
+        "saloonphp",
         "saloon",
         "sdk",
         "api",
@@ -21,15 +21,14 @@
     "require": {
         "php": "^8.1",
         "illuminate/console": "^10.0",
-        "illuminate/http": "^10.0",
         "illuminate/support": "^10.0",
-        "saloonphp/saloon": "^3.0"
+        "saloonphp/saloon": "^3.5"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.5",
-        "orchestra/testbench": "^v7.30 || ^v8.10",
-        "pestphp/pest": "^v1.23",
-        "phpstan/phpstan": "^1.9"
+        "friendsofphp/php-cs-fixer": "^3.48",
+        "orchestra/testbench": "^8.21",
+        "pestphp/pest": "^2.32",
+        "phpstan/phpstan": "^1.10.56"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/src/Casts/EncryptedOAuthAuthenticatorCast.php
+++ b/src/Casts/EncryptedOAuthAuthenticatorCast.php
@@ -24,10 +24,8 @@ class EncryptedOAuthAuthenticatorCast implements CastsAttributes
 
     /**
      * Prepare the given value for storage.
-     *
-     * @return mixed|void
      */
-    public function set($model, string $key, $value, array $attributes)
+    public function set($model, string $key, $value, array $attributes): ?string
     {
         if (is_null($value)) {
             return null;

--- a/src/Casts/OAuthAuthenticatorCast.php
+++ b/src/Casts/OAuthAuthenticatorCast.php
@@ -24,10 +24,8 @@ class OAuthAuthenticatorCast implements CastsAttributes
 
     /**
      * Prepare the given value for storage.
-     *
-     * @return mixed|void
      */
-    public function set($model, string $key, $value, array $attributes)
+    public function set($model, string $key, $value, array $attributes): ?string
     {
         if (is_null($value)) {
             return null;

--- a/src/Console/Commands/MakeConnector.php
+++ b/src/Console/Commands/MakeConnector.php
@@ -45,7 +45,12 @@ class MakeConnector extends MakeCommand
             : 'saloon.connector.stub';
     }
 
-    protected function getOptions()
+    /**
+     * Get the options for making a connector
+     *
+     * @return array<int, array<mixed>>
+     */
+    protected function getOptions(): array
     {
         return [
             ['oauth', null, InputOption::VALUE_NONE, 'Whether the connector should include the OAuth boilerplate'],

--- a/src/Console/Commands/MakeRequest.php
+++ b/src/Console/Commands/MakeRequest.php
@@ -6,6 +6,7 @@ namespace Saloon\Laravel\Console\Commands;
 
 use Saloon\Enums\Method;
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use function Laravel\Prompts\select;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -49,6 +50,11 @@ class MakeRequest extends MakeCommand
      */
     protected $stub = 'saloon.request.stub';
 
+    /**
+     * Get the options for making a request
+     *
+     * @return array<int, array<mixed>>
+     */
     protected function getOptions(): array
     {
         return [
@@ -82,8 +88,14 @@ class MakeRequest extends MakeCommand
      */
     protected function buildClass($name): MakeRequest|string
     {
+        $method = $this->option('method') ?? 'GET';
+
+        if (! is_string($method)) {
+            throw new InvalidArgumentException('The method option must be a string.');
+        }
+
         $stub = $this->files->get($this->getStub());
-        $stub = $this->replaceMethod($stub, $this->option('method') ?? 'GET');
+        $stub = $this->replaceMethod($stub, $method);
 
         return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
     }

--- a/src/Facades/Saloon.php
+++ b/src/Facades/Saloon.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Saloon\Laravel\Facades;
 
 use Saloon\Http\Response;
+use Illuminate\Support\Facades\Facade;
 use Saloon\Laravel\Http\Faking\MockClient;
-use Illuminate\Support\Facades\Facade as BaseFacade;
 
 /**
+ * @deprecated You should use MockClient::global() instead. This facade will be removed in Saloon v4.
+ *
  * @see \Saloon\Laravel\Saloon
  *
  * @method static MockClient fake(array $responses)
@@ -25,7 +27,7 @@ use Illuminate\Support\Facades\Facade as BaseFacade;
  * @method static \Saloon\Http\Response[] getRecordedResponses()
  * @method static \Saloon\Http\Response getLastRecordedResponse()
  */
-class Saloon extends BaseFacade
+class Saloon extends Facade
 {
     /**
      * Register the Saloon facade

--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -6,6 +6,9 @@ namespace Saloon\Laravel\Http\Faking;
 
 use Saloon\Http\Faking\MockClient as BaseMockClient;
 
+/**
+ * @deprecated You should use MockClient::global() instead. This class will be removed in Saloon v4.
+ */
 class MockClient extends BaseMockClient
 {
     /**
@@ -18,7 +21,6 @@ class MockClient extends BaseMockClient
      *
      * @param array<\Saloon\Http\Faking\MockResponse|\Saloon\Http\Faking\Fixture|callable> $responses
      * @return $this
-     * @throws \Saloon\Exceptions\InvalidMockResponseCaptureMethodException
      */
     public function startMocking(array $responses = []): self
     {

--- a/src/Saloon.php
+++ b/src/Saloon.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Saloon\Laravel;
 
 use Saloon\Http\Response;
-use Saloon\Laravel\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockClient;
 
+/**
+ * @deprecated You should use MockClient::global() instead. This class will be removed in Saloon v4.
+ */
 class Saloon
 {
     /**
@@ -30,25 +33,22 @@ class Saloon
      * Start mocking!
      *
      * @param array<\Saloon\Http\Faking\MockResponse|\Saloon\Http\Faking\Fixture|callable> $responses
-     * @throws \Saloon\Exceptions\InvalidMockResponseCaptureMethodException
      */
     public static function fake(array $responses): MockClient
     {
-        return MockClient::resolve()->startMocking($responses);
+        return MockClient::global($responses);
     }
 
     /**
-     * Retrieve the mock client from the container
+     * Retrieve the global mock client
      */
     public static function mockClient(): MockClient
     {
-        return MockClient::resolve();
+        return MockClient::global();
     }
 
     /**
      * Assert that a given request was sent.
-     *
-     * @throws \ReflectionException
      */
     public static function assertSent(string|callable $value): void
     {
@@ -57,8 +57,6 @@ class Saloon
 
     /**
      * Assert that a given request was not sent.
-     *
-     * @throws \ReflectionException
      */
     public static function assertNotSent(string|callable $value): void
     {
@@ -69,7 +67,6 @@ class Saloon
      * Assert JSON data was sent
      *
      * @param array<string, mixed> $data
-     * @throws \ReflectionException
      */
     public static function assertSentJson(string $request, array $data): void
     {

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -16,6 +16,7 @@ use Saloon\Laravel\Console\Commands\MakeResponse;
 use Saloon\Laravel\Console\Commands\MakeConnector;
 use Saloon\Laravel\Http\Middleware\MockMiddleware;
 use Saloon\Laravel\Http\Middleware\RecordResponse;
+use Saloon\Http\Faking\MockClient as BaseMockClient;
 use Saloon\Laravel\Http\Middleware\SendRequestEvent;
 use Saloon\Laravel\Http\Middleware\SendResponseEvent;
 use Saloon\Laravel\Console\Commands\MakeAuthenticator;
@@ -24,10 +25,8 @@ class SaloonServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->mergeConfigFrom(
             __DIR__ . '/../config/saloon.php',
@@ -37,8 +36,6 @@ class SaloonServiceProvider extends ServiceProvider
 
     /**
      * Handle the booting of the service provider.
-     *
-     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
     public function boot(): void
     {
@@ -69,6 +66,10 @@ class SaloonServiceProvider extends ServiceProvider
 
             Saloon::$registeredDefaults = true;
         }
+
+        // Destroy global mock client to prevent leaky tests
+
+        BaseMockClient::destroyGlobal();
     }
 
     /**


### PR DESCRIPTION
This PR makes a few changes

- Deprecated the `Saloon` facade
- Deprecated the `MockClient` class if people were using it
- Uses the new Global Mock Client internally for mocking
- Automatically destroys the global mock client in the service provider
- Fixes PHPStan issues
- Installs PHPStan workflow file
- Introduces PHP 8.3 for testing