### PR TITLE
Use Integrations Path when creating new classes

### DIFF
--- a/src/Console/Commands/MakeCommand.php
+++ b/src/Console/Commands/MakeCommand.php
@@ -88,8 +88,6 @@ abstract class MakeCommand extends GeneratorCommand
 
     /**
      * Returns the namespace without the default Saloon parts
-     *
-     * @return string
      */
     protected function getFormattedNamespace(): string
     {
@@ -98,11 +96,11 @@ abstract class MakeCommand extends GeneratorCommand
 
     /**
      * Converts the integrations path to a namespace friendly string
-     *
-     * @return string
      */
     protected function getNamespaceFromIntegrationsPath(): string
     {
-        return str_replace(['\\App', '\\app'], '', str_replace("/", "\\", str_replace(base_path(), '', config('saloon.integrations_path'))));
+        $namespace = (array)str_replace(['\\App', '\\app'], '', str_replace('/', '\\', str_replace(base_path(), '', config('saloon.integrations_path'))));
+
+        return $namespace[0];
     }
 }

--- a/src/Console/Commands/MakeCommand.php
+++ b/src/Console/Commands/MakeCommand.php
@@ -57,7 +57,9 @@ abstract class MakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return str_replace('{integration}', $this->getIntegration(), $rootNamespace . $this->namespace);
+        $namespace = $this->getNamespaceFromIntegrationsPath() . $this->getFormattedNamespace();
+
+        return str_replace('{integration}', $this->getIntegration(), $rootNamespace . $namespace);
     }
 
     protected function getIntegration(): string
@@ -82,5 +84,25 @@ abstract class MakeCommand extends GeneratorCommand
             ['integration', InputArgument::REQUIRED, 'The related integration'],
             ...parent::getArguments(),
         ];
+    }
+
+    /**
+     * Returns the namespace without the default Saloon parts
+     *
+     * @return string
+     */
+    protected function getFormattedNamespace(): string
+    {
+        return str_replace('\\Http\\Integrations', '', $this->namespace);
+    }
+
+    /**
+     * Converts the integrations path to a namespace friendly string
+     *
+     * @return string
+     */
+    protected function getNamespaceFromIntegrationsPath(): string
+    {
+        return str_replace(['\\App', '\\app'], '', str_replace("/", "\\", str_replace(base_path(), '', config('saloon.integrations_path'))));
     }
 }


### PR DESCRIPTION
Fixes #47 

When working on https://github.com/saloonphp/laravel-plugin/pull/46, I added the ability to specify an `integrations_path` within the Saloon config file, so that if an application was using a different architecture, such as DDD, the `saloon:list` command would continue to work, providing that the config value was set correctly. 

This PR goes one step further with that config value, in that if it's set, it will create classes in that path. Let's say we have an application using the DDD approach. Instead of our integrations living in the default location of `app/Http/Integrations`, we have them in `app/Domain` and have updated the `saloon.integrations_path` so it's correct, when we run `php artisan saloon:request` and fill in all the prompts, you'll see:

![image](https://github.com/saloonphp/laravel-plugin/assets/7534029/7436b4fd-f043-40b7-9e8e-49d262880840)

_Note the path in the confirmation message_

If we wanted to segment them further, perhaps we integrate with multiple Payment APIs,  we could set _Payment/Stripe_ as the Integration name, and that will give us the following:

![image](https://github.com/saloonphp/laravel-plugin/assets/7534029/404c1ca2-986e-413d-bfa7-79b22f6f1526)

If the `saloon.integrations_path` config isn't set in the application, then it will fallback to use the default location of `app/Http/Integrations`:

![image](https://github.com/saloonphp/laravel-plugin/assets/7534029/f7415db4-8fac-44ef-86c1-5b9d2ed17d49)

I can also confirm that `saloon:list` will still work:

![image](https://github.com/saloonphp/laravel-plugin/assets/7534029/5f8fb5da-0f4c-4caa-b38b-87f887b24100)


I'm pretty happy with the little amount of code this took to achieve. This update has definitely been a long time coming, that's for sure! As always, I'm happy for any feedback! 

