### PR TITLE
Feature | Reuse Global Mock Client With Saloon::fake()

### DIFF
--- a/src/Saloon.php
+++ b/src/Saloon.php
@@ -36,7 +36,11 @@ class Saloon
      */
     public static function fake(array $responses): MockClient
     {
-        return MockClient::global($responses);
+        $mockClient = static::mockClient();
+
+        $mockClient->addResponses($responses);
+
+        return $mockClient;
     }
 
     /**
@@ -44,7 +48,7 @@ class Saloon
      */
     public static function mockClient(): MockClient
     {
-        return MockClient::global();
+        return MockClient::getGlobal() ?? MockClient::global();
     }
 
     /**

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Faking\MockClient;
 use Saloon\Http\PendingRequest;
+use Saloon\Http\Faking\MockClient;
 use Saloon\Laravel\Facades\Saloon;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Exceptions\NoMockResponseFoundException;

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Faking\MockClient;
 use Saloon\Http\PendingRequest;
 use Saloon\Laravel\Facades\Saloon;
 use Saloon\Http\Faking\MockResponse;
@@ -230,4 +231,23 @@ test('a request can be mocked with a url defined using a closure', function () {
     expect($responseA->isMocked())->toBeTrue();
     expect($responseA->json())->toEqual(['request' => 'https://tests.saloon.dev/api/user']);
     expect($responseA->status())->toEqual(200);
+});
+
+test('the same global mock client is reused on further calls', function () {
+    $mockClientA = Saloon::fake([
+        new MockResponse(['name' => 'Sam'], 200),
+    ]);
+
+    $mockClientB = Saloon::fake([
+        new MockResponse(['name' => 'Alex'], 200),
+    ]);
+
+    expect(MockClient::getGlobal())->toEqual(new MockClient([
+        new MockResponse(['name' => 'Sam'], 200),
+        new MockResponse(['name' => 'Alex'], 200),
+    ]));
+    
+    expect($mockClientA)->toBe($mockClientB);
+    expect($mockClientA)->toBe(Saloon::mockClient());
+    expect($mockClientB)->toBe(Saloon::mockClient());
 });


### PR DESCRIPTION
This PR fixes #57

This PR changes the way the new Global Mock client is implemented so now multiple `Saloon::fake()` calls will result in the responses being built up, rather than replacing the responses every time.