### PR TITLE
Add guzzle sender that extends Saloon's default sender (linked to PR in saloon itself)

### DIFF
--- a/config/saloon.php
+++ b/config/saloon.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Laravel\Http\Senders\GuzzleSender;
 
 return [
 

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Saloon\Laravel\Http\Senders;
+
+use GuzzleHttp\Client as GuzzleClient;
+use Saloon\Http\Senders\GuzzleSender as BaseGuzzleSender;
+
+class GuzzleSender extends BaseGuzzleSender
+{
+    protected function createGuzzleClient(): GuzzleClient
+    {
+        return app()->makeWith(GuzzleClient::class, $this->getGuzzleClientConfig());
+    }
+}


### PR DESCRIPTION
I noticed the `laravel-http-sender` package is being sunset, but I still want requests/responses to be logged in Telescope. Then I discovered this is possible with the following package: https://github.com/huzaifaarain/telescope-guzzle-watcher/tree/main

The problem is that this package only works if the guzzle client is created using the service container. That is currently not the case.

This PR and PR https://github.com/saloonphp/saloon/pull/403 make that possible with minimal changes.