### PR TITLE
Add Nightwatch middleware and corresponding tests

### DIFF
--- a/src/Http/Middleware/NightwatchMiddleware.php
+++ b/src/Http/Middleware/NightwatchMiddleware.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Laravel\Http\Middleware;
+
+use Saloon\Http\PendingRequest;
+use Saloon\Contracts\RequestMiddleware;
+
+class NightwatchMiddleware implements RequestMiddleware
+{
+    /**
+     * Apply Nightwatch middleware to Guzzle requests when using GuzzleSender
+     */
+    public function __invoke(PendingRequest $pendingRequest): void
+    {
+        $sender = $pendingRequest->getConnector()->sender();
+
+        // Check if Nightwatch is installed
+        if (! class_exists('Nightwatch\\Nightwatch')) {
+            return;
+        }
+
+        // Check if we're using GuzzleSender
+        if ($sender instanceof \Saloon\Http\Senders\GuzzleSender === false) {
+            return;
+        }
+
+        $sender->addMiddleware(\Nightwatch\Nightwatch::guzzleMiddleware(), 'nightwatch');
+    }
+
+}

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -20,6 +20,7 @@ use Saloon\Http\Faking\MockClient as BaseMockClient;
 use Saloon\Laravel\Http\Middleware\SendRequestEvent;
 use Saloon\Laravel\Http\Middleware\SendResponseEvent;
 use Saloon\Laravel\Console\Commands\MakeAuthenticator;
+use Saloon\Laravel\Http\Middleware\NightwatchMiddleware;
 
 class SaloonServiceProvider extends ServiceProvider
 {
@@ -60,6 +61,7 @@ class SaloonServiceProvider extends ServiceProvider
 
             Config::globalMiddleware()
                 ->onRequest(new MockMiddleware, 'laravelMock')
+                ->onRequest(new NightwatchMiddleware, 'laravelNightwatch')
                 ->onRequest(new SendRequestEvent, 'laravelSendRequestEvent', PipeOrder::LAST)
                 ->onResponse(new RecordResponse, 'laravelRecordResponse', PipeOrder::FIRST)
                 ->onResponse(new SendResponseEvent, 'laravelSendResponseEvent', PipeOrder::FIRST);

--- a/tests/Feature/NightwatchMiddlewareTest.php
+++ b/tests/Feature/NightwatchMiddlewareTest.php
@@ -32,4 +32,3 @@ test('nightwatch middleware checks for guzzle sender', function () {
         $middleware($pendingRequest);
     })->not->toThrow(Exception::class);
 });
-

--- a/tests/Feature/NightwatchMiddlewareTest.php
+++ b/tests/Feature/NightwatchMiddlewareTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\PendingRequest;
+use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Laravel\Http\Middleware\NightwatchMiddleware;
+use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
+
+test('nightwatch middleware is invoked without errors when nightwatch is not available', function () {
+    $connector = TestConnector::make();
+    $request = new UserRequest();
+    $pendingRequest = new PendingRequest($connector, $request);
+
+    $middleware = new NightwatchMiddleware();
+
+    // Should not throw any exceptions even when Nightwatch is not available
+    expect(function () use ($middleware, $pendingRequest) {
+        $middleware($pendingRequest);
+    })->not->toThrow(Exception::class);
+});
+
+test('nightwatch middleware checks for guzzle sender', function () {
+    $connector = TestConnector::make();
+    $request = new UserRequest();
+    $pendingRequest = new PendingRequest($connector, $request);
+
+    $middleware = new NightwatchMiddleware();
+
+    // Should handle gracefully for any sender type
+    expect(function () use ($middleware, $pendingRequest) {
+        $middleware($pendingRequest);
+    })->not->toThrow(Exception::class);
+});
+


### PR DESCRIPTION
I'm not sure about the implementation, but I hope it's what you expected 😄

Feel free to edit my PR ;)

* Added `NightwatchMiddleware` to apply Nightwatch middleware to Guzzle requests when Nightwatch is installed and `GuzzleSender` is used.
* Registered middleware in `SaloonServiceProvider` for global automatic application.