### PR TITLE
Use correct file path for integration path

### DIFF
--- a/config/saloon.php
+++ b/config/saloon.php
@@ -34,5 +34,5 @@ return [
     |
     */
 
-    'integrations_path' => base_path('App/Http/Integrations'),
+    'integrations_path' => base_path('app/Http/Integrations'),
 ];


### PR DESCRIPTION
The default path wasn't a valid directory path due to the capitalized `App` (instead of `app`):

```
$ php artisan saloon:list

   Symfony\Component\Finder\Exception\DirectoryNotFoundException 

  The "/var/www/html/App/Http/Integrations" directory does not exist.
```