### PR TITLE
Suggest Existing Integrations

### DIFF
--- a/src/Console/Commands/MakeAuthenticator.php
+++ b/src/Console/Commands/MakeAuthenticator.php
@@ -50,7 +50,7 @@ class MakeAuthenticator extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon authenticator be named?',
+            'name' => 'What should the Saloon authenticator be named?',
         ];
     }
 }

--- a/src/Console/Commands/MakeAuthenticator.php
+++ b/src/Console/Commands/MakeAuthenticator.php
@@ -50,7 +50,7 @@ class MakeAuthenticator extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon authenticator be named?'
+            'name' => 'What should the saloon authenticator be named?',
         ];
     }
 }

--- a/src/Console/Commands/MakeAuthenticator.php
+++ b/src/Console/Commands/MakeAuthenticator.php
@@ -40,4 +40,17 @@ class MakeAuthenticator extends MakeCommand
      * @var string
      */
     protected $stub = 'saloon.authenticator.stub';
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array<string, string|\Closure>
+     */
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            ...parent::promptForMissingArgumentsUsing(),
+            'name' => 'What should the saloon authenticator be named?'
+        ];
+    }
 }

--- a/src/Console/Commands/MakeCommand.php
+++ b/src/Console/Commands/MakeCommand.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Saloon\Laravel\Console\Commands;
 
-use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Facades\File;
-use Symfony\Component\Console\Input\InputArgument;
 use function Laravel\Prompts\suggest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputArgument;
 
 abstract class MakeCommand extends GeneratorCommand
 {
@@ -119,15 +119,15 @@ abstract class MakeCommand extends GeneratorCommand
         }
 
         $directories = File::directories($integrationsPath);
-        $integrations = array_map(fn($path) => basename($path), $directories);
+        $integrations = array_map(fn ($path) => basename($path), $directories);
 
-        if (strlen($search) === 0) {
+        if (mb_strlen($search) === 0) {
             return $integrations;
         }
 
         return array_values(array_filter(
             $integrations,
-            fn ($integration) => str_contains(strtolower($integration), strtolower($search))
+            fn ($integration) => str_contains(mb_strtolower($integration), mb_strtolower($search))
         ));
     }
 

--- a/src/Console/Commands/MakeCommand.php
+++ b/src/Console/Commands/MakeCommand.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Saloon\Laravel\Console\Commands;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Facades\File;
 use Symfony\Component\Console\Input\InputArgument;
+use function Laravel\Prompts\suggest;
 
 abstract class MakeCommand extends GeneratorCommand
 {
@@ -84,6 +86,49 @@ abstract class MakeCommand extends GeneratorCommand
             ['integration', InputArgument::REQUIRED, 'The related integration'],
             ...parent::getArguments(),
         ];
+    }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array<string, string|\Closure>
+     */
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            'integration' => fn () => suggest(
+                label: 'What is the related integration?',
+                options: fn (string $value) => $this->getExistingIntegrations($value),
+                required: true,
+                hint: 'Start typing to search or enter a new integration name'
+            ),
+        ];
+    }
+
+    /**
+     * Get existing integrations filtered by search value via prompt
+     *
+     * @return array<int, string>
+     */
+    protected function getExistingIntegrations(string $search = ''): array
+    {
+        $integrationsPath = config('saloon.integrations_path');
+
+        if (! File::isDirectory($integrationsPath)) {
+            return [];
+        }
+
+        $directories = File::directories($integrationsPath);
+        $integrations = array_map(fn($path) => basename($path), $directories);
+
+        if (strlen($search) === 0) {
+            return $integrations;
+        }
+
+        return array_values(array_filter(
+            $integrations,
+            fn ($integration) => str_contains(strtolower($integration), strtolower($search))
+        ));
     }
 
     /**

--- a/src/Console/Commands/MakeConnector.php
+++ b/src/Console/Commands/MakeConnector.php
@@ -82,7 +82,7 @@ class MakeConnector extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon connector be named?',
+            'name' => 'What should the Saloon connector be named?',
         ];
     }
 }

--- a/src/Console/Commands/MakeConnector.php
+++ b/src/Console/Commands/MakeConnector.php
@@ -82,7 +82,7 @@ class MakeConnector extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon connector be named?'
+            'name' => 'What should the saloon connector be named?',
         ];
     }
 }

--- a/src/Console/Commands/MakeConnector.php
+++ b/src/Console/Commands/MakeConnector.php
@@ -72,4 +72,17 @@ class MakeConnector extends MakeCommand
 
         $input->setOption('oauth', $supportOauth);
     }
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array<string, string|\Closure>
+     */
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            ...parent::promptForMissingArgumentsUsing(),
+            'name' => 'What should the saloon connector be named?'
+        ];
+    }
 }

--- a/src/Console/Commands/MakePlugin.php
+++ b/src/Console/Commands/MakePlugin.php
@@ -50,7 +50,7 @@ class MakePlugin extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon plugin be named?'
+            'name' => 'What should the saloon plugin be named?',
         ];
     }
 }

--- a/src/Console/Commands/MakePlugin.php
+++ b/src/Console/Commands/MakePlugin.php
@@ -50,7 +50,7 @@ class MakePlugin extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon plugin be named?',
+            'name' => 'What should the Saloon plugin be named?',
         ];
     }
 }

--- a/src/Console/Commands/MakePlugin.php
+++ b/src/Console/Commands/MakePlugin.php
@@ -40,4 +40,17 @@ class MakePlugin extends MakeCommand
      * @var string
      */
     protected $stub = 'saloon.plugin.stub';
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array<string, string|\Closure>
+     */
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            ...parent::promptForMissingArgumentsUsing(),
+            'name' => 'What should the saloon plugin be named?'
+        ];
+    }
 }

--- a/src/Console/Commands/MakeRequest.php
+++ b/src/Console/Commands/MakeRequest.php
@@ -63,6 +63,19 @@ class MakeRequest extends MakeCommand
     }
 
     /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array<string, string|\Closure>
+     */
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            ...parent::promptForMissingArgumentsUsing(),
+            'name' => 'What should the saloon request be named?'
+        ];
+    }
+
+    /**
      * Interact further with the user if they were prompted for missing arguments.
      */
     protected function afterPromptingForMissingArguments(InputInterface $input, OutputInterface $output): void

--- a/src/Console/Commands/MakeRequest.php
+++ b/src/Console/Commands/MakeRequest.php
@@ -71,7 +71,7 @@ class MakeRequest extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon request be named?',
+            'name' => 'What should the Saloon request be named?',
         ];
     }
 

--- a/src/Console/Commands/MakeRequest.php
+++ b/src/Console/Commands/MakeRequest.php
@@ -71,7 +71,7 @@ class MakeRequest extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon request be named?'
+            'name' => 'What should the saloon request be named?',
         ];
     }
 

--- a/src/Console/Commands/MakeResponse.php
+++ b/src/Console/Commands/MakeResponse.php
@@ -40,4 +40,17 @@ class MakeResponse extends MakeCommand
      * @var string
      */
     protected $stub = 'saloon.response.stub';
+
+    /**
+     * Prompt for missing input arguments using the returned questions.
+     *
+     * @return array<string, string|\Closure>
+     */
+    protected function promptForMissingArgumentsUsing(): array
+    {
+        return [
+            ...parent::promptForMissingArgumentsUsing(),
+            'name' => 'What should the saloon response be named?'
+        ];
+    }
 }

--- a/src/Console/Commands/MakeResponse.php
+++ b/src/Console/Commands/MakeResponse.php
@@ -50,7 +50,7 @@ class MakeResponse extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon response be named?',
+            'name' => 'What should the Saloon response be named?',
         ];
     }
 }

--- a/src/Console/Commands/MakeResponse.php
+++ b/src/Console/Commands/MakeResponse.php
@@ -50,7 +50,7 @@ class MakeResponse extends MakeCommand
     {
         return [
             ...parent::promptForMissingArgumentsUsing(),
-            'name' => 'What should the saloon response be named?'
+            'name' => 'What should the saloon response be named?',
         ];
     }
 }


### PR DESCRIPTION
This is something I've wanted to add to this package for a while now and I finally dedicated some time to getting it done!

Historically, whenever you add a new connector, request, response etc.. you have to _type_ the Integration it's for. This is fine, but if you make a typo or forget the name of the integration, you end up with an integration that either needs renaming or deleting and you have to start over.

This PR introduces the _suggest_ Laravel Prompt so when you get asked for the Integration, you can now either select from your existing integrations _or_ type in the name for a new one

<img width="604" height="240" alt="Screenshot 2025-11-21 at 10 37 40" src="https://github.com/user-attachments/assets/2ce2bf89-ec78-40ad-b9fc-ef0a6ada0a90" />

It's not immediately clear that you can type the name of a non-existing integration, so I've added some extra information in the `hint` of the prompt. 