### PR TITLE
Laravel Telescope Integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.48",
+        "laravel/telescope": "^5.16",
         "orchestra/testbench": "^9.15 || ^10.7",
         "pestphp/pest": "^3.0|^4.0",
         "phpstan/phpstan": "^1.10.57|^2.0.2"

--- a/src/Http/Middleware/TelescopeMiddleware.php
+++ b/src/Http/Middleware/TelescopeMiddleware.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Laravel\Http\Middleware;
+
+use Saloon\Http\PendingRequest;
+use Illuminate\Support\Facades\Event;
+use Saloon\Contracts\RequestMiddleware;
+use Saloon\Laravel\Events\SentSaloonRequest;
+use Saloon\Laravel\Events\SendingSaloonRequest;
+
+class TelescopeMiddleware implements RequestMiddleware
+{
+    /**
+     * Track start time for duration calculation
+     *
+     * @var array<int, float>
+     */
+    protected static array $startTimes = [];
+
+    /**
+     * Whether event listeners have been registered
+     */
+    protected static bool $listenersRegistered = false;
+
+    /**
+     * Create a new Telescope middleware instance
+     */
+    public function __construct()
+    {
+        // Register event listeners once
+        if (! self::$listenersRegistered) {
+            Event::listen(SendingSaloonRequest::class, [self::class, 'handleSending']);
+            Event::listen(SentSaloonRequest::class, [self::class, 'handleSent']);
+            self::$listenersRegistered = true;
+        }
+    }
+
+    public function __invoke(PendingRequest $pendingRequest): void
+    {
+    }
+
+    /**
+     * Handle the SendingSaloonRequest event
+     */
+    public static function handleSending(SendingSaloonRequest $event): void
+    {
+        // Check if Telescope is installed
+        if (! class_exists('Laravel\Telescope\Telescope')) {
+            return;
+        }
+
+        $pendingRequest = $event->pendingRequest;
+
+        // Record start time for duration calculation
+        $requestId = spl_object_id($pendingRequest);
+        self::$startTimes[$requestId] = microtime(true);
+    }
+
+    /**
+     * Handle the SentSaloonRequest event
+     */
+    public static function handleSent(SentSaloonRequest $event): void
+    {
+        // Check if Telescope is installed
+        if (! class_exists('Laravel\Telescope\Telescope')) {
+            return;
+        }
+
+        $pendingRequest = $event->pendingRequest;
+        $response = $event->response;
+
+        $requestId = spl_object_id($pendingRequest);
+        $startTime = self::$startTimes[$requestId] ?? null;
+
+        // Calculate duration
+        $duration = $startTime !== null ? (int) ((microtime(true) - $startTime) * 1000) : null;
+
+        // Clean up start time
+        unset(self::$startTimes[$requestId]);
+
+        // Record to Telescope
+        self::recordToTelescope($pendingRequest, $response, $duration);
+    }
+
+    /**
+     * Record the request to Telescope
+     */
+    protected static function recordToTelescope(\Saloon\Http\PendingRequest $pendingRequest, \Saloon\Http\Response $response, ?int $duration): void
+    {
+        // @phpstan-ignore-next-line
+        if (! \Laravel\Telescope\Telescope::isRecording()) {
+            return;
+        }
+
+        $psrRequest = $pendingRequest->createPsrRequest();
+        $psrResponse = $response->getPsrResponse();
+
+        // Format request data
+        $requestData = [
+            'method' => $psrRequest->getMethod(),
+            'url' => (string) $psrRequest->getUri(),
+            'headers' => $psrRequest->getHeaders(),
+            'body' => self::formatBody((string) $psrRequest->getBody(), $psrRequest->getHeaderLine('Content-Type')),
+        ];
+
+        // Format response data
+        $responseData = [
+            'status' => $psrResponse->getStatusCode(),
+            'headers' => $psrResponse->getHeaders(),
+            'body' => self::formatBody((string) $psrResponse->getBody(), $psrResponse->getHeaderLine('Content-Type')),
+        ];
+
+        // Record to Telescope using IncomingEntry
+        // @phpstan-ignore-next-line
+        $entry = \Laravel\Telescope\IncomingEntry::make([
+            'method' => $requestData['method'],
+            'uri' => $requestData['url'],
+            'headers' => $requestData['headers'],
+            'payload' => $requestData['body'],
+            'response_status' => $responseData['status'],
+            'response_headers' => $responseData['headers'],
+            'response' => $responseData['body'],
+            'duration' => $duration,
+        ])->tags(['saloon']);
+
+        // @phpstan-ignore-next-line
+        \Laravel\Telescope\Telescope::recordClientRequest($entry);
+    }
+
+    /**
+     * Format body for display
+     *
+     * @return array<string, mixed>|string
+     */
+    protected static function formatBody(string $body, string $contentType): array|string
+    {
+        if (empty($body)) {
+            return '';
+        }
+
+        // Try to decode JSON
+        if (str_contains($contentType, 'application/json')) {
+            $decoded = json_decode($body, true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $decoded;
+            }
+        }
+
+        // Try to decode form data
+        if (str_contains($contentType, 'application/x-www-form-urlencoded')) {
+            parse_str($body, $formData);
+
+            // @phpstan-ignore-next-line - parse_str can create numeric keys but we treat as string keys
+            return $formData;
+        }
+
+        // Return as string
+        return $body;
+    }
+}

--- a/src/Http/Middleware/TelescopeRequestMiddleware.php
+++ b/src/Http/Middleware/TelescopeRequestMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Laravel\Http\Middleware;
+
+use Saloon\Laravel\Saloon;
+use Saloon\Http\PendingRequest;
+use Saloon\Contracts\RequestMiddleware;
+
+class TelescopeRequestMiddleware implements RequestMiddleware
+{
+    public function __invoke(PendingRequest $pendingRequest): void
+    {
+        // Check if Telescope is installed
+
+        if (! class_exists('Laravel\Telescope\Telescope')) {
+            return;
+        }
+
+        // Record start time for duration calculation
+        $requestId = spl_object_id($pendingRequest);
+
+        Saloon::$telescopeStartTimes[$requestId] = microtime(true);
+    }
+}

--- a/src/Http/Middleware/TelescopeResponseMiddleware.php
+++ b/src/Http/Middleware/TelescopeResponseMiddleware.php
@@ -4,90 +4,41 @@ declare(strict_types=1);
 
 namespace Saloon\Laravel\Http\Middleware;
 
+use Saloon\Http\Response;
+use Saloon\Laravel\Saloon;
 use Saloon\Http\PendingRequest;
-use Illuminate\Support\Facades\Event;
-use Saloon\Contracts\RequestMiddleware;
-use Saloon\Laravel\Events\SentSaloonRequest;
-use Saloon\Laravel\Events\SendingSaloonRequest;
+use Saloon\Contracts\ResponseMiddleware;
 
-class TelescopeMiddleware implements RequestMiddleware
+class TelescopeResponseMiddleware implements ResponseMiddleware
 {
-    /**
-     * Track start time for duration calculation
-     *
-     * @var array<int, float>
-     */
-    protected static array $startTimes = [];
-
-    /**
-     * Whether event listeners have been registered
-     */
-    protected static bool $listenersRegistered = false;
-
-    /**
-     * Create a new Telescope middleware instance
-     */
-    public function __construct()
-    {
-        // Register event listeners once
-        if (! self::$listenersRegistered) {
-            Event::listen(SendingSaloonRequest::class, [self::class, 'handleSending']);
-            Event::listen(SentSaloonRequest::class, [self::class, 'handleSent']);
-            self::$listenersRegistered = true;
-        }
-    }
-
-    public function __invoke(PendingRequest $pendingRequest): void
-    {
-    }
-
-    /**
-     * Handle the SendingSaloonRequest event
-     */
-    public static function handleSending(SendingSaloonRequest $event): void
+    public function __invoke(Response $response): void
     {
         // Check if Telescope is installed
+
         if (! class_exists('Laravel\Telescope\Telescope')) {
             return;
         }
 
-        $pendingRequest = $event->pendingRequest;
-
-        // Record start time for duration calculation
-        $requestId = spl_object_id($pendingRequest);
-        self::$startTimes[$requestId] = microtime(true);
-    }
-
-    /**
-     * Handle the SentSaloonRequest event
-     */
-    public static function handleSent(SentSaloonRequest $event): void
-    {
-        // Check if Telescope is installed
-        if (! class_exists('Laravel\Telescope\Telescope')) {
-            return;
-        }
-
-        $pendingRequest = $event->pendingRequest;
-        $response = $event->response;
+        $pendingRequest = $response->getPendingRequest();
 
         $requestId = spl_object_id($pendingRequest);
-        $startTime = self::$startTimes[$requestId] ?? null;
+        $startTime = Saloon::$telescopeStartTimes[$requestId] ?? null;
 
         // Calculate duration
-        $duration = $startTime !== null ? (int) ((microtime(true) - $startTime) * 1000) : null;
+        $duration = $startTime !== null ? (int)((microtime(true) - $startTime) * 1000) : null;
 
         // Clean up start time
-        unset(self::$startTimes[$requestId]);
+        unset(Saloon::$telescopeStartTimes[$requestId]);
 
         // Record to Telescope
-        self::recordToTelescope($pendingRequest, $response, $duration);
+
+        $this->recordToTelescope($pendingRequest, $response, $duration);
     }
 
     /**
      * Record the request to Telescope
      */
-    protected static function recordToTelescope(\Saloon\Http\PendingRequest $pendingRequest, \Saloon\Http\Response $response, ?int $duration): void
+    protected function recordToTelescope(PendingRequest $pendingRequest, Response $response, ?int $duration): void
     {
         // @phpstan-ignore-next-line
         if (! \Laravel\Telescope\Telescope::isRecording()) {
@@ -100,16 +51,16 @@ class TelescopeMiddleware implements RequestMiddleware
         // Format request data
         $requestData = [
             'method' => $psrRequest->getMethod(),
-            'url' => (string) $psrRequest->getUri(),
+            'url' => (string)$psrRequest->getUri(),
             'headers' => $psrRequest->getHeaders(),
-            'body' => self::formatBody((string) $psrRequest->getBody(), $psrRequest->getHeaderLine('Content-Type')),
+            'body' => self::formatBody((string)$psrRequest->getBody(), $psrRequest->getHeaderLine('Content-Type')),
         ];
 
         // Format response data
         $responseData = [
             'status' => $psrResponse->getStatusCode(),
             'headers' => $psrResponse->getHeaders(),
-            'body' => self::formatBody((string) $psrResponse->getBody(), $psrResponse->getHeaderLine('Content-Type')),
+            'body' => self::formatBody((string)$psrResponse->getBody(), $psrResponse->getHeaderLine('Content-Type')),
         ];
 
         // Record to Telescope using IncomingEntry

--- a/src/Http/Middleware/TelescopeResponseMiddleware.php
+++ b/src/Http/Middleware/TelescopeResponseMiddleware.php
@@ -40,7 +40,6 @@ class TelescopeResponseMiddleware implements ResponseMiddleware
      */
     protected function recordToTelescope(PendingRequest $pendingRequest, Response $response, ?int $duration): void
     {
-        // @phpstan-ignore-next-line
         if (! \Laravel\Telescope\Telescope::isRecording()) {
             return;
         }
@@ -64,7 +63,6 @@ class TelescopeResponseMiddleware implements ResponseMiddleware
         ];
 
         // Record to Telescope using IncomingEntry
-        // @phpstan-ignore-next-line
         $entry = \Laravel\Telescope\IncomingEntry::make([
             'method' => $requestData['method'],
             'uri' => $requestData['url'],
@@ -76,7 +74,6 @@ class TelescopeResponseMiddleware implements ResponseMiddleware
             'duration' => $duration,
         ])->tags(['saloon']);
 
-        // @phpstan-ignore-next-line
         \Laravel\Telescope\Telescope::recordClientRequest($entry);
     }
 

--- a/src/Saloon.php
+++ b/src/Saloon.php
@@ -37,6 +37,13 @@ class Saloon
     protected array $recordedResponses = [];
 
     /**
+     * Track start time for Telescope duration calculation
+     *
+     * @var array<int, float>
+     */
+    public static array $telescopeStartTimes = [];
+
+    /**
      * Start mocking!
      *
      * @param array<\Saloon\Http\Faking\MockResponse|\Saloon\Http\Faking\Fixture|callable> $responses

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -20,6 +20,7 @@ use Saloon\Http\Faking\MockClient as BaseMockClient;
 use Saloon\Laravel\Http\Middleware\SendRequestEvent;
 use Saloon\Laravel\Http\Middleware\SendResponseEvent;
 use Saloon\Laravel\Console\Commands\MakeAuthenticator;
+use Saloon\Laravel\Http\Middleware\TelescopeMiddleware;
 use Saloon\Laravel\Http\Middleware\NightwatchMiddleware;
 
 class SaloonServiceProvider extends ServiceProvider
@@ -62,6 +63,7 @@ class SaloonServiceProvider extends ServiceProvider
             Config::globalMiddleware()
                 ->onRequest(new MockMiddleware, 'laravelMock')
                 ->onRequest(new NightwatchMiddleware, 'laravelNightwatch')
+                ->onRequest(new TelescopeMiddleware, 'laravelTelescope')
                 ->onRequest(new SendRequestEvent, 'laravelSendRequestEvent', PipeOrder::LAST)
                 ->onResponse(new RecordResponse, 'laravelRecordResponse', PipeOrder::FIRST)
                 ->onResponse(new SendResponseEvent, 'laravelSendResponseEvent', PipeOrder::FIRST);

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -20,8 +20,9 @@ use Saloon\Http\Faking\MockClient as BaseMockClient;
 use Saloon\Laravel\Http\Middleware\SendRequestEvent;
 use Saloon\Laravel\Http\Middleware\SendResponseEvent;
 use Saloon\Laravel\Console\Commands\MakeAuthenticator;
-use Saloon\Laravel\Http\Middleware\TelescopeMiddleware;
 use Saloon\Laravel\Http\Middleware\NightwatchMiddleware;
+use Saloon\Laravel\Http\Middleware\TelescopeRequestMiddleware;
+use Saloon\Laravel\Http\Middleware\TelescopeResponseMiddleware;
 
 class SaloonServiceProvider extends ServiceProvider
 {
@@ -63,10 +64,11 @@ class SaloonServiceProvider extends ServiceProvider
             Config::globalMiddleware()
                 ->onRequest(new MockMiddleware, 'laravelMock')
                 ->onRequest(new NightwatchMiddleware, 'laravelNightwatch')
-                ->onRequest(new TelescopeMiddleware, 'laravelTelescope')
+                ->onRequest(new TelescopeRequestMiddleware, 'laravelTelescopeRequest')
                 ->onRequest(new SendRequestEvent, 'laravelSendRequestEvent', PipeOrder::LAST)
                 ->onResponse(new RecordResponse, 'laravelRecordResponse', PipeOrder::FIRST)
-                ->onResponse(new SendResponseEvent, 'laravelSendResponseEvent', PipeOrder::FIRST);
+                ->onResponse(new SendResponseEvent, 'laravelSendResponseEvent', PipeOrder::FIRST)
+                ->onResponse(new TelescopeResponseMiddleware, 'laravelTelescopeResponse');
 
             Saloon::$registeredDefaults = true;
         }
@@ -79,6 +81,7 @@ class SaloonServiceProvider extends ServiceProvider
 
         $this->app->terminating(function () {
             Saloon::$registeredSenders = [];
+            Saloon::$telescopeStartTimes = [];
         });
     }
 

--- a/tests/Feature/TelescopeMiddlewareTest.php
+++ b/tests/Feature/TelescopeMiddlewareTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\PendingRequest;
+use Saloon\Laravel\Events\SentSaloonRequest;
+use Saloon\Laravel\Events\SendingSaloonRequest;
+use Saloon\Laravel\Http\Middleware\TelescopeMiddleware;
+use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
+
+test('telescope middleware handles sending event without errors when telescope is not available', function () {
+    $connector = TestConnector::make();
+    $request = new UserRequest();
+    $pendingRequest = new PendingRequest($connector, $request);
+    $event = new SendingSaloonRequest($pendingRequest);
+
+    $middleware = new TelescopeMiddleware();
+
+    // Should not throw any exceptions even when Telescope is not available
+    expect(function () use ($middleware, $event) {
+        $middleware->handleSending($event);
+    })->not->toThrow(Exception::class);
+});
+
+test('telescope middleware works with any sender', function () {
+    $connector = TestConnector::make();
+    $request = new UserRequest();
+    $pendingRequest = new PendingRequest($connector, $request);
+    $event = new SendingSaloonRequest($pendingRequest);
+
+    $middleware = new TelescopeMiddleware();
+
+    // Should handle gracefully for any sender type
+    expect(function () use ($middleware, $event) {
+        TelescopeMiddleware::handleSending($event);
+    })->not->toThrow(Exception::class);
+});
+
+test('telescope middleware tracks start time', function () {
+    $connector = TestConnector::make();
+    $request = new UserRequest();
+    $pendingRequest = new PendingRequest($connector, $request);
+    $event = new SendingSaloonRequest($pendingRequest);
+
+    $middleware = new TelescopeMiddleware();
+    $middleware->handleSending($event);
+
+    // Start time should be tracked (we can't easily verify this without reflection,
+    // but we can verify it doesn't throw)
+    expect(true)->toBeTrue();
+});
+
+test('telescope middleware calculates duration', function () {
+    $connector = TestConnector::make();
+    $request = new UserRequest();
+    $pendingRequest = new PendingRequest($connector, $request);
+    
+    // Create a mock response
+    $psrRequest = $pendingRequest->createPsrRequest();
+    $psrResponse = new \GuzzleHttp\Psr7\Response(200, [], '{"name":"Test"}');
+    $response = \Saloon\Http\Response::fromPsrResponse($psrResponse, $pendingRequest, $psrRequest);
+
+    $sendingEvent = new SendingSaloonRequest($pendingRequest);
+    $sentEvent = new SentSaloonRequest($pendingRequest, $response);
+
+    $middleware = new TelescopeMiddleware();
+    
+    // Handle sending event to set start time
+    $middleware->handleSending($sendingEvent);
+    
+    // Small delay
+    usleep(1000); // 1ms
+    
+    // Handle sent event
+    expect(function () use ($middleware, $sentEvent) {
+        $middleware->handleSent($sentEvent);
+    })->not->toThrow(Exception::class);
+});
+
+test('telescope middleware formats json body', function () {
+    $middleware = new TelescopeMiddleware();
+    
+    $reflection = new ReflectionClass($middleware);
+    $method = $reflection->getMethod('formatBody');
+    
+    $jsonBody = '{"name":"Test","value":123}';
+    $formatted = $method->invoke($middleware, $jsonBody, 'application/json');
+    
+    expect($formatted)->toBeArray();
+    expect($formatted)->toHaveKeys(['name', 'value']);
+    expect($formatted['name'])->toBe('Test');
+    expect($formatted['value'])->toBe(123);
+});
+
+test('telescope middleware formats form body', function () {
+    $middleware = new TelescopeMiddleware();
+    
+    $reflection = new ReflectionClass($middleware);
+    $method = $reflection->getMethod('formatBody');
+    
+    $formBody = 'name=Test&value=123';
+    $formatted = $method->invoke($middleware, $formBody, 'application/x-www-form-urlencoded');
+    
+    expect($formatted)->toBeArray();
+    expect($formatted)->toHaveKeys(['name', 'value']);
+    expect($formatted['name'])->toBe('Test');
+    expect($formatted['value'])->toBe('123');
+});
+
+test('telescope middleware returns string for non-json non-form body', function () {
+    $middleware = new TelescopeMiddleware();
+    
+    $reflection = new ReflectionClass($middleware);
+    $method = $reflection->getMethod('formatBody');
+    
+    $plainBody = 'plain text body';
+    $formatted = $method->invoke($middleware, $plainBody, 'text/plain');
+    
+    expect($formatted)->toBeString();
+    expect($formatted)->toBe('plain text body');
+});

--- a/tests/Feature/TelescopeMiddlewareTest.php
+++ b/tests/Feature/TelescopeMiddlewareTest.php
@@ -2,24 +2,23 @@
 
 declare(strict_types=1);
 
+use Saloon\Laravel\Saloon;
 use Saloon\Http\PendingRequest;
-use Saloon\Laravel\Events\SentSaloonRequest;
-use Saloon\Laravel\Events\SendingSaloonRequest;
-use Saloon\Laravel\Http\Middleware\TelescopeMiddleware;
 use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Laravel\Http\Middleware\TelescopeRequestMiddleware;
+use Saloon\Laravel\Http\Middleware\TelescopeResponseMiddleware;
 
 test('telescope middleware handles sending event without errors when telescope is not available', function () {
     $connector = TestConnector::make();
     $request = new UserRequest();
     $pendingRequest = new PendingRequest($connector, $request);
-    $event = new SendingSaloonRequest($pendingRequest);
 
-    $middleware = new TelescopeMiddleware();
+    $middleware = new TelescopeRequestMiddleware();
 
     // Should not throw any exceptions even when Telescope is not available
-    expect(function () use ($middleware, $event) {
-        $middleware->handleSending($event);
+    expect(function () use ($middleware, $pendingRequest) {
+        $middleware->__invoke($pendingRequest);
     })->not->toThrow(Exception::class);
 });
 
@@ -27,66 +26,62 @@ test('telescope middleware works with any sender', function () {
     $connector = TestConnector::make();
     $request = new UserRequest();
     $pendingRequest = new PendingRequest($connector, $request);
-    $event = new SendingSaloonRequest($pendingRequest);
 
-    $middleware = new TelescopeMiddleware();
+    $middleware = new TelescopeRequestMiddleware();
 
     // Should handle gracefully for any sender type
-    expect(function () use ($middleware, $event) {
-        TelescopeMiddleware::handleSending($event);
+    expect(function () use ($middleware, $pendingRequest) {
+        $middleware->__invoke($pendingRequest);
     })->not->toThrow(Exception::class);
 });
 
 test('telescope middleware tracks start time', function () {
     $connector = TestConnector::make();
     $request = new UserRequest();
+
+    expect(Saloon::$telescopeStartTimes)->toHaveCount(0);
+
     $pendingRequest = new PendingRequest($connector, $request);
-    $event = new SendingSaloonRequest($pendingRequest);
 
-    $middleware = new TelescopeMiddleware();
-    $middleware->handleSending($event);
+    $middleware = new TelescopeRequestMiddleware();
+    $middleware->__invoke($pendingRequest);
 
-    // Start time should be tracked (we can't easily verify this without reflection,
-    // but we can verify it doesn't throw)
-    expect(true)->toBeTrue();
+    expect(Saloon::$telescopeStartTimes)->toHaveCount(1);
 });
 
 test('telescope middleware calculates duration', function () {
     $connector = TestConnector::make();
     $request = new UserRequest();
     $pendingRequest = new PendingRequest($connector, $request);
-    
+
     // Create a mock response
     $psrRequest = $pendingRequest->createPsrRequest();
     $psrResponse = new \GuzzleHttp\Psr7\Response(200, [], '{"name":"Test"}');
     $response = \Saloon\Http\Response::fromPsrResponse($psrResponse, $pendingRequest, $psrRequest);
 
-    $sendingEvent = new SendingSaloonRequest($pendingRequest);
-    $sentEvent = new SentSaloonRequest($pendingRequest, $response);
+    $middleware = new TelescopeRequestMiddleware();
 
-    $middleware = new TelescopeMiddleware();
-    
     // Handle sending event to set start time
-    $middleware->handleSending($sendingEvent);
-    
+    $middleware->__invoke($pendingRequest);
+
     // Small delay
     usleep(1000); // 1ms
-    
+
     // Handle sent event
-    expect(function () use ($middleware, $sentEvent) {
-        $middleware->handleSent($sentEvent);
+    expect(function () use ($response) {
+        (new TelescopeResponseMiddleware)->__invoke($response);
     })->not->toThrow(Exception::class);
 });
 
 test('telescope middleware formats json body', function () {
-    $middleware = new TelescopeMiddleware();
-    
+    $middleware = new TelescopeResponseMiddleware();
+
     $reflection = new ReflectionClass($middleware);
     $method = $reflection->getMethod('formatBody');
-    
+
     $jsonBody = '{"name":"Test","value":123}';
     $formatted = $method->invoke($middleware, $jsonBody, 'application/json');
-    
+
     expect($formatted)->toBeArray();
     expect($formatted)->toHaveKeys(['name', 'value']);
     expect($formatted['name'])->toBe('Test');
@@ -94,14 +89,14 @@ test('telescope middleware formats json body', function () {
 });
 
 test('telescope middleware formats form body', function () {
-    $middleware = new TelescopeMiddleware();
-    
+    $middleware = new TelescopeResponseMiddleware();
+
     $reflection = new ReflectionClass($middleware);
     $method = $reflection->getMethod('formatBody');
-    
+
     $formBody = 'name=Test&value=123';
     $formatted = $method->invoke($middleware, $formBody, 'application/x-www-form-urlencoded');
-    
+
     expect($formatted)->toBeArray();
     expect($formatted)->toHaveKeys(['name', 'value']);
     expect($formatted['name'])->toBe('Test');
@@ -109,14 +104,14 @@ test('telescope middleware formats form body', function () {
 });
 
 test('telescope middleware returns string for non-json non-form body', function () {
-    $middleware = new TelescopeMiddleware();
-    
+    $middleware = new TelescopeResponseMiddleware();
+
     $reflection = new ReflectionClass($middleware);
     $method = $reflection->getMethod('formatBody');
-    
+
     $plainBody = 'plain text body';
     $formatted = $method->invoke($middleware, $plainBody, 'text/plain');
-    
+
     expect($formatted)->toBeString();
     expect($formatted)->toBe('plain text body');
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,9 +13,15 @@ declare(strict_types=1);
 |
 */
 
+use Saloon\Laravel\Saloon;
 use Saloon\Laravel\Tests\TestCase;
 
 uses(TestCase::class)->in('Feature', 'Unit');
+
+pest()->afterEach(function () {
+    Saloon::$registeredSenders = [];
+    Saloon::$telescopeStartTimes = [];
+});
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/saloonphp/saloon/issues/529

We recently sunsetted https://github.com/saloonphp/laravel-http-sender however it's still useful to be able to see Saloon triggered requests in Telescope, for local debugging. This PR re-adds an integration with Laravel Telescope, but without needing an extra package. With this PR, you'll be able to see requests appear in Telescope, under the "HTTP Client" tab without configuring the sender to `HttpSender` in the `saloon.php` config file.

<img width="1208" height="588" alt="Screenshot 2025-12-15 at 18 07 15" src="https://github.com/user-attachments/assets/46514c73-ee88-489e-ba0d-cb003dda1520" />
