### PR TITLE
Prevent Nightwatch middleware from being registered multiple times

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
             "./vendor/bin/php-cs-fixer fix --allow-risky=yes"
         ],
         "pstan": [
-            "./vendor/bin/phpstan analyse"
+            "./vendor/bin/phpstan analyse --memory-limit=2G"
         ],
         "test": [
             "./vendor/bin/pest"

--- a/src/Http/Middleware/NightwatchMiddleware.php
+++ b/src/Http/Middleware/NightwatchMiddleware.php
@@ -27,6 +27,13 @@ class NightwatchMiddleware implements RequestMiddleware
             return;
         }
 
+        // Ensure that the Nightwatch middleware is only registered once on the
+        // handler stack. For long-lived connectors, this middleware may be
+        // invoked multiple times, so remove any existing Nightwatch
+        // middleware before re-adding it to prevent oversampling.
+        $handlerStack = $sender->getHandlerStack();
+        $handlerStack->remove('nightwatch');
+
         $sender->addMiddleware(\Laravel\Nightwatch\Facades\Nightwatch::guzzleMiddleware(), 'nightwatch');
 
     }

--- a/src/Http/Middleware/NightwatchMiddleware.php
+++ b/src/Http/Middleware/NightwatchMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Laravel\Http\Middleware;
 
+use Saloon\Laravel\Saloon;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Senders\GuzzleSender;
 use Saloon\Contracts\RequestMiddleware;
@@ -17,25 +18,19 @@ class NightwatchMiddleware implements RequestMiddleware
     {
         $sender = $pendingRequest->getConnector()->sender();
 
-        // Check if Nightwatch is installed
-        if (! class_exists('Laravel\Nightwatch\Facades\Nightwatch')) {
+        // Check if we're using the Guzzle Sender, Nightwatch is installed and
+        // if the middleware hasn't been registered yet.
+
+        if (
+            class_exists('Laravel\Nightwatch\Facades\Nightwatch') === false
+            || $sender instanceof GuzzleSender === false
+            || isset(Saloon::$registeredSenders[$senderId = spl_object_id($sender)]['nightwatch']) === true
+        ) {
             return;
         }
-
-        // Check if we're using GuzzleSender
-        if ($sender instanceof GuzzleSender === false) {
-            return;
-        }
-
-        // Ensure that the Nightwatch middleware is only registered once on the
-        // handler stack. For long-lived connectors, this middleware may be
-        // invoked multiple times, so remove any existing Nightwatch
-        // middleware before re-adding it to prevent oversampling.
-        $handlerStack = $sender->getHandlerStack();
-        $handlerStack->remove('nightwatch');
 
         $sender->addMiddleware(\Laravel\Nightwatch\Facades\Nightwatch::guzzleMiddleware(), 'nightwatch');
 
+        Saloon::$registeredSenders[$senderId]['nightwatch'] = true;
     }
-
 }

--- a/src/Saloon.php
+++ b/src/Saloon.php
@@ -18,6 +18,13 @@ class Saloon
     public static bool $registeredDefaults = false;
 
     /**
+     * Define sender IDs that have been used before
+     *
+     * @var array<int, array<string, bool>>
+     */
+    public static array $registeredSenders = [];
+
+    /**
      * Determines if requests should be recorded.
      */
     protected bool $record = false;

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -69,9 +69,15 @@ class SaloonServiceProvider extends ServiceProvider
             Saloon::$registeredDefaults = true;
         }
 
-        // Destroy global mock client to prevent leaky tests
+        $this->app->terminating(static function () {
+            // Destroy global mock client to prevent leaky tests
 
-        BaseMockClient::destroyGlobal();
+            BaseMockClient::destroyGlobal();
+
+            // Clear registered senders to prevent Octane memory leaks
+
+            Saloon::$registeredSenders = [];
+        });
     }
 
     /**

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -69,7 +69,7 @@ class SaloonServiceProvider extends ServiceProvider
             Saloon::$registeredDefaults = true;
         }
 
-        $this->app->terminating(static function () {
+        $this->app->terminating(function () {
             // Destroy global mock client to prevent leaky tests
 
             BaseMockClient::destroyGlobal();

--- a/src/SaloonServiceProvider.php
+++ b/src/SaloonServiceProvider.php
@@ -69,13 +69,13 @@ class SaloonServiceProvider extends ServiceProvider
             Saloon::$registeredDefaults = true;
         }
 
+        // Destroy global mock client to prevent leaky tests
+
+        BaseMockClient::destroyGlobal();
+
+        // Clear registered senders to prevent Octane memory leaks
+
         $this->app->terminating(function () {
-            // Destroy global mock client to prevent leaky tests
-
-            BaseMockClient::destroyGlobal();
-
-            // Clear registered senders to prevent Octane memory leaks
-
             Saloon::$registeredSenders = [];
         });
     }

--- a/tests/Feature/NightwatchMiddlewareTest.php
+++ b/tests/Feature/NightwatchMiddlewareTest.php
@@ -3,9 +3,10 @@
 declare(strict_types=1);
 
 use Saloon\Http\PendingRequest;
-use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Http\Senders\GuzzleSender;
 use Saloon\Laravel\Http\Middleware\NightwatchMiddleware;
 use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
 
 test('nightwatch middleware is invoked without errors when nightwatch is not available', function () {
     $connector = TestConnector::make();
@@ -31,4 +32,47 @@ test('nightwatch middleware checks for guzzle sender', function () {
     expect(function () use ($middleware, $pendingRequest) {
         $middleware($pendingRequest);
     })->not->toThrow(Exception::class);
+});
+
+test('nightwatch middleware is only registered once on the handler stack for long-lived connectors', function () {
+    if (! class_exists('Laravel\Nightwatch\Facades\Nightwatch')) {
+        require_once __DIR__ . '/../Fixtures/Middleware/NightwatchMock.php';
+    }
+
+    $connector = TestConnector::make();
+    $pendingRequest = new PendingRequest($connector, new UserRequest());
+
+    $sender = $connector->sender();
+    $this->assertInstanceOf(GuzzleSender::class, $sender);
+
+    $handlerStack = $sender->getHandlerStack();
+
+    $middleware = new NightwatchMiddleware();
+
+    // Simulate multiple requests being sent
+    $middleware($pendingRequest);
+    $middleware($pendingRequest);
+
+    /*
+     *    Handler stack __toString() renders middleware as in > and out <.
+     *    Example:
+     *    > 5) Name: 'http_errors', Function: callable(00000000000004130000000000000000)
+     *   > 4) Name: 'allow_redirects', Function: callable(00000000000004120000000000000000)
+     *   > 3) Name: 'cookies', Function: callable(00000000000004110000000000000000)
+     *   > 2) Name: 'prepare_body', Function: callable(00000000000004100000000000000000)
+     *   > 1) Name: 'nightwatch', Function: callable(00000000000004440000000000000000)
+     *   < 0) Handler: callable(00000000000004170000000000000000)
+     *   < 1) Name: 'nightwatch', Function: callable(00000000000004440000000000000000)
+     *   < 2) Name: 'prepare_body', Function: callable(00000000000004100000000000000000)
+     *   < 3) Name: 'cookies', Function: callable(00000000000004110000000000000000)
+     *   < 4) Name: 'allow_redirects', Function: callable(00000000000004120000000000000000)
+     *   < 5) Name: 'http_errors', Function: callable(00000000000004130000000000000000)
+     *
+     *   Count only the ">" section to avoid double counting
+     */
+    $stackString = (string) $handlerStack;
+    $reverseSection = explode('<', $stackString)[0] ?? '';
+    $nightwatchCount = substr_count($reverseSection, "Name: 'nightwatch'");
+
+    expect($nightwatchCount)->toBe(1);
 });

--- a/tests/Feature/NightwatchMiddlewareTest.php
+++ b/tests/Feature/NightwatchMiddlewareTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Laravel\Http\Middleware\NightwatchMiddleware;
 use Saloon\Laravel\Tests\Fixtures\Connectors\TestConnector;
-use Saloon\Laravel\Tests\Fixtures\Requests\UserRequest;
 
 test('nightwatch middleware is invoked without errors when nightwatch is not available', function () {
     $connector = TestConnector::make();
@@ -72,7 +72,7 @@ test('nightwatch middleware is only registered once on the handler stack for lon
      */
     $stackString = (string) $handlerStack;
     $reverseSection = explode('<', $stackString)[0] ?? '';
-    $nightwatchCount = substr_count($reverseSection, "Name: 'nightwatch'");
+    $nightwatchCount = mb_substr_count($reverseSection, 'Name: \'nightwatch\'');
 
     expect($nightwatchCount)->toBe(1);
 });

--- a/tests/Fixtures/Middleware/NightwatchMock.php
+++ b/tests/Fixtures/Middleware/NightwatchMock.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Nightwatch\Facades;
+
+/**
+ * Mock Nightwatch facade for testing when Nightwatch is not installed.
+ * This allows us to test the handler stack manipulation with a real GuzzleSender.
+ * Note: our namespace needs to match the Laravel Nightwatch facade
+ */
+class Nightwatch
+{
+    public static function guzzleMiddleware(): callable
+    {
+        return function (callable $handler): callable {
+            return function ($request, $options) use ($handler) {
+                return $handler($request, $options);
+            };
+        };
+    }
+}
+

--- a/tests/Fixtures/Middleware/NightwatchMock.php
+++ b/tests/Fixtures/Middleware/NightwatchMock.php
@@ -20,4 +20,3 @@ class Nightwatch
         };
     }
 }
-


### PR DESCRIPTION
### Summary

When the Nightwatch middleware is added to a connector that is reused across multiple requests, the middleware is registered repeatedly on subsequent requests. This results in duplicate middleware execution and inflated Nightwatch metrics.

### Problem

The Nightwatch plugin registers its middleware via `addMiddleware` on the Guzzle `handlerStack`, which does not de-duplicate entries. When a Connector instance is reused, the Nightwatch middleware is appended again on each request, causing the middleware to run multiple times per request lifecycle.

Because Nightwatch is intended to observe outgoing requests once per execution, this leads to significant oversampling.

### Fix

Before registering the Nightwatch middleware, remove any existing middleware tagged as `nightwatch` from the handler stack. This ensures the middleware is only applied once, even when connectors are reused.

### Tests

- Added a regression test that reproduces the middleware duplication when reusing a connector.
- The test fails on `main` and passes with this change.
- Verified that the Nightwatch middleware executes only once per request across multiple uses of the same connector instance.