### PR TITLE
Fix for missed endblock for available-docs

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -69,4 +69,5 @@
 - [https://docs.saloon.dev/installable-plugins/lawman] Use these docs for the Lawman plugin, a PestPHP plugin for writing architecture tests for API integrations
 - [https://docs.saloon.dev/installable-plugins/xml-wrangler] Use these docs for the XML Wrangler plugin for modern XML reading and writing with dot notation and XPath queries
 - [https://docs.saloon.dev/installable-plugins/building-your-own-plugins] Use these docs for building custom plugins (traits), creating boot methods, and extending Saloon functionality
+
 </available-docs>


### PR DESCRIPTION
boost description needs to be clear with a line-break for the closing tag. This simple fix adds the line-break needed to discern end of section