### PR TITLE
Fix telescope response middleware when response body only contains integer but content-type header of response says its json

### DIFF
--- a/src/Http/Middleware/TelescopeResponseMiddleware.php
+++ b/src/Http/Middleware/TelescopeResponseMiddleware.php
@@ -92,7 +92,7 @@ class TelescopeResponseMiddleware implements ResponseMiddleware
         if (str_contains($contentType, 'application/json')) {
             $decoded = json_decode($body, true);
             if (json_last_error() === JSON_ERROR_NONE) {
-                return $decoded;
+                return is_array($decoded) ? $decoded : (string) $decoded;
             }
         }
 

--- a/tests/Feature/TelescopeMiddlewareTest.php
+++ b/tests/Feature/TelescopeMiddlewareTest.php
@@ -115,3 +115,16 @@ test('telescope middleware returns string for non-json non-form body', function 
     expect($formatted)->toBeString();
     expect($formatted)->toBe('plain text body');
 });
+
+test('telescope middleware returns string for non-json body when header says response is json', function () {
+    $middleware = new TelescopeResponseMiddleware();
+
+    $reflection = new ReflectionClass($middleware);
+    $method = $reflection->getMethod('formatBody');
+
+    $plainBody = 123456;
+    $formatted = $method->invoke($middleware, $plainBody, 'application/json');
+
+    expect($formatted)->toBeString();
+    expect($formatted)->toBe('123456');
+});


### PR DESCRIPTION
I'm dealing with annoying third-party api call that sends a response with the `content-type: application/json` header but the response body is just an integer (= an id). Currently the `TelescopeResponseMiddleware` throws an exception because the decoded 'json' is an integer instead of an array or string. This PR ensures that the middleware does not fail anymore in that case.