### PR TITLE
Add Laravel 13 support to illuminate constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "homepage": "https://github.com/saloonphp/laravel-plugin",
     "require": {
         "php": "^8.2",
-        "illuminate/console": "^11.0 || ^v12.39.0",
-        "illuminate/support": "^11.0 || ^12.39.0",
+        "illuminate/console": "^11.0 || ^12.39.0 || ^13.0",
+        "illuminate/support": "^11.0 || ^12.39.0 || ^13.0",
         "saloonphp/saloon": "^3.5",
         "symfony/finder": "^6.4 || ^7.0"
     },


### PR DESCRIPTION
Adds ^13.0 to the illuminate/console and illuminate/support version constraints, enabling installation  alongside Laravel 13. No source code changes required — the library is fully compatible as-is. Also normalizes ^v12.39.0 to ^12.39.0 on illuminate/console.