### PR TITLE
Add v4 version info to boost guideline & skill

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -6,6 +6,6 @@
 
 - PHP library for building API integrations and SDKs.
 - Documentation: https://docs.saloon.dev
-- Check `composer.json` for version (v2 or v3). Use `web-search` tool for latest docs before implementing.
+- Check `composer.json` for version (v2, v3 or v4). Use `web-search` tool for latest docs before implementing.
 - Always use Artisan commands to generate SaloonPHP classes: `{{ $assist->artisanCommand('saloon:connector') }}`, `{{ $assist->artisanCommand('saloon:request') }}`, `{{ $assist->artisanCommand('saloon:response') }}`, `{{ $assist->artisanCommand('php artisan saloon:plugin') }}`, `{{ $assist->artisanCommand('saloon:auth') }}`.- Documentation: `https://docs.saloon.dev`
 - IMPORTANT: Activate saloon-development skill when working with SaloonPHP-related tasks.

--- a/resources/boost/skills/saloon-development/SKILL.md
+++ b/resources/boost/skills/saloon-development/SKILL.md
@@ -17,7 +17,7 @@ Use this skill when working with SaloonPHP features:
 
 ## Documentation
 
-Use `web-search` for docs at https://docs.saloon.dev. Check `composer.json` for version (v2 or v3).
+Use `web-search` for docs at https://docs.saloon.dev. Check `composer.json` for version (v2, v3 or v4).
 
 ## Features
 
@@ -103,7 +103,7 @@ Store classes in `app/Http/Integrations/{ServiceName}/` (configurable in `config
 - Forgetting `HasBody` interface when sending body data
 - Wrong HTTP method enum (use `Saloon\Enums\Method`)
 - Missing `HttpSender` config for Telescope
-- v3: forgetting to install pagination plugin
+- v3 or v4: forgetting to install pagination plugin
 
 ## Available Documentation
 
@@ -111,6 +111,7 @@ Use `web-search` with these docs for specific topics:
 
 ## Upgrade
 
+- [https://docs.saloon.dev/upgrade/upgrading-from-v3-to-v4] Use these docs to understand what's new in SaloonPHP v4
 - [https://docs.saloon.dev/upgrade/whats-new-in-v3] Use these docs to understand what's new in SaloonPHP v3
 - [https://docs.saloon.dev/upgrade/upgrading-from-v2] Use these docs for upgrading from SaloonPHP v2 to v3
 


### PR DESCRIPTION
This PR adds info about v4 to the Boost guideline and the skill.

Perhaps there also should be added a recommendation for the AI to tell the user that an upgrade from v3 to v4 is highly recommended?