### PR TITLE
fix: show HAL+JSON responses correctly in Telescope

### DIFF
--- a/src/Http/Middleware/TelescopeResponseMiddleware.php
+++ b/src/Http/Middleware/TelescopeResponseMiddleware.php
@@ -141,6 +141,13 @@ class TelescopeResponseMiddleware implements ResponseMiddleware
                 : 'Purged By Telescope';
         }
 
+        if (is_array(json_decode($formatted, true))
+            && json_last_error() === JSON_ERROR_NONE) {
+            return $this->contentWithinLimits($rawBody)
+                ? $this->hideParameters(json_decode($formatted, true), Telescope::$hiddenResponseParameters)
+                : 'Purged By Telescope';
+        }
+
         if (Str::startsWith($contentType, 'text/plain')) {
             return $this->contentWithinLimits($formatted) ? $formatted : 'Purged By Telescope';
         }
@@ -193,7 +200,7 @@ class TelescopeResponseMiddleware implements ResponseMiddleware
         }
 
         // Try to decode JSON
-        if (str_contains($contentType, 'application/json')) {
+        if (self::isJsonContentType($contentType)) {
             $decoded = json_decode($body, true);
             if (json_last_error() === JSON_ERROR_NONE) {
                 return is_array($decoded) ? $decoded : (string) $decoded;
@@ -210,5 +217,11 @@ class TelescopeResponseMiddleware implements ResponseMiddleware
 
         // Return as string
         return $body;
+    }
+
+    protected static function isJsonContentType(string $contentType): bool
+    {
+        return str_contains($contentType, 'application/json')
+            || str_contains($contentType, '+json');
     }
 }

--- a/tests/Feature/TelescopeMiddlewareTest.php
+++ b/tests/Feature/TelescopeMiddlewareTest.php
@@ -133,6 +133,46 @@ test('telescope middleware returns string for non-json body when header says res
     expect($formatted)->toBe('123456');
 });
 
+test('telescope middleware formats hal+json body', function () {
+    $middleware = new TelescopeResponseMiddleware;
+
+    $reflection = new ReflectionClass($middleware);
+    $method = $reflection->getMethod('formatBody');
+
+    $jsonBody = '{"_links":{"self":{"href":"/api/users/1"}},"name":"Test"}';
+    $formatted = $method->invoke($middleware, $jsonBody, 'application/hal+json');
+
+    expect($formatted)->toBeArray();
+    expect($formatted)->toHaveKeys(['_links', 'name']);
+    expect($formatted['name'])->toBe('Test');
+});
+
+test('telescope middleware formats hal+json body with charset', function () {
+    $middleware = new TelescopeResponseMiddleware;
+
+    $reflection = new ReflectionClass($middleware);
+    $method = $reflection->getMethod('formatBody');
+
+    $jsonBody = '{"id":1}';
+    $formatted = $method->invoke($middleware, $jsonBody, 'application/hal+json; charset=utf-8');
+
+    expect($formatted)->toBeArray();
+    expect($formatted['id'])->toBe(1);
+});
+
+test('telescope middleware formats json api body', function () {
+    $middleware = new TelescopeResponseMiddleware;
+
+    $reflection = new ReflectionClass($middleware);
+    $method = $reflection->getMethod('formatBody');
+
+    $jsonBody = '{"data":{"type":"users","id":"1"}}';
+    $formatted = $method->invoke($middleware, $jsonBody, 'application/vnd.api+json');
+
+    expect($formatted)->toBeArray();
+    expect($formatted['data']['type'])->toBe('users');
+});
+
 /**
  * @return array{hiddenRequestParameters: array<int, string>, hiddenRequestHeaders: array<int, string>, hiddenResponseParameters: array<int, string>, shouldRecord: bool}
  */
@@ -256,6 +296,104 @@ test('telescope response middleware redacts application/x-www-form-urlencoded pa
         expect($entry->content['payload']['password'])->toBe('********');
         expect($entry->content['payload']['email'])->toBe('a@b.test');
         expect($entry->content['payload']['name'])->toBe('test');
+    } finally {
+        restoreTelescopeRedactionSettings($snapshot);
+    }
+});
+
+test('telescope response middleware records hal+json response as array', function () {
+    $snapshot = snapshotTelescopeRedactionSettings();
+
+    try {
+        Telescope::flushEntries();
+        Telescope::$shouldRecord = true;
+        Telescope::$hiddenRequestParameters = [];
+        Telescope::$hiddenRequestHeaders = [];
+        Telescope::$hiddenResponseParameters = [];
+
+        $connector = TestConnector::make();
+        $request = new PostSensitiveJsonRequest;
+        $pendingRequest = new PendingRequest($connector, $request);
+
+        (new TelescopeRequestMiddleware)->__invoke($pendingRequest);
+
+        $psrRequest = $pendingRequest->createPsrRequest();
+        $responseBody = json_encode(['_links' => ['self' => ['href' => '/api/users/1']], 'name' => 'Test']);
+        $psrResponse = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/hal+json'], $responseBody);
+        $response = \Saloon\Http\Response::fromPsrResponse($psrResponse, $pendingRequest, $psrRequest);
+
+        (new TelescopeResponseMiddleware)->__invoke($response);
+
+        $entry = collect(Telescope::$entriesQueue)->last(fn ($e) => $e->type === EntryType::CLIENT_REQUEST);
+
+        expect($entry)->not->toBeNull();
+        expect($entry->content['response'])->toBeArray();
+        expect($entry->content['response'])->not->toBe('HTML Response');
+        expect($entry->content['response']['name'])->toBe('Test');
+    } finally {
+        restoreTelescopeRedactionSettings($snapshot);
+    }
+});
+
+test('telescope response middleware redacts hal+json response fields using hidden response parameters', function () {
+    $snapshot = snapshotTelescopeRedactionSettings();
+
+    try {
+        Telescope::flushEntries();
+        Telescope::$shouldRecord = true;
+        Telescope::$hiddenRequestParameters = [];
+        Telescope::$hiddenRequestHeaders = [];
+        Telescope::$hiddenResponseParameters = ['access_token'];
+
+        $connector = TestConnector::make();
+        $request = new PostSensitiveJsonRequest;
+        $pendingRequest = new PendingRequest($connector, $request);
+
+        (new TelescopeRequestMiddleware)->__invoke($pendingRequest);
+
+        $psrRequest = $pendingRequest->createPsrRequest();
+        $responseBody = json_encode(['access_token' => 'secret-token-value', 'expires_in' => 3600]);
+        $psrResponse = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'application/hal+json'], $responseBody);
+        $response = \Saloon\Http\Response::fromPsrResponse($psrResponse, $pendingRequest, $psrRequest);
+
+        (new TelescopeResponseMiddleware)->__invoke($response);
+
+        $entry = collect(Telescope::$entriesQueue)->last(fn ($e) => $e->type === EntryType::CLIENT_REQUEST);
+
+        expect($entry)->not->toBeNull();
+        expect($entry->content['response']['access_token'])->toBe('********');
+        expect($entry->content['response']['expires_in'])->toBe(3600);
+    } finally {
+        restoreTelescopeRedactionSettings($snapshot);
+    }
+});
+
+test('telescope response middleware records html response as html response label', function () {
+    $snapshot = snapshotTelescopeRedactionSettings();
+
+    try {
+        Telescope::flushEntries();
+        Telescope::$shouldRecord = true;
+        Telescope::$hiddenRequestParameters = [];
+        Telescope::$hiddenRequestHeaders = [];
+        Telescope::$hiddenResponseParameters = [];
+
+        $connector = TestConnector::make();
+        $request = new PostSensitiveJsonRequest;
+        $pendingRequest = new PendingRequest($connector, $request);
+
+        (new TelescopeRequestMiddleware)->__invoke($pendingRequest);
+
+        $psrRequest = $pendingRequest->createPsrRequest();
+        $psrResponse = new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'text/html'], '<html><body>Hello</body></html>');
+        $response = \Saloon\Http\Response::fromPsrResponse($psrResponse, $pendingRequest, $psrRequest);
+
+        (new TelescopeResponseMiddleware)->__invoke($response);
+
+        $entry = collect(Telescope::$entriesQueue)->last(fn ($e) => $e->type === EntryType::CLIENT_REQUEST);
+
+        expect($entry)->not->toBeNull();
+        expect($entry->content['response'])->toBe('HTML Response');
     } finally {
         restoreTelescopeRedactionSettings($snapshot);
     }


### PR DESCRIPTION
## Why

Telescope entries for Saloon client requests only decode bodies when the content type contains `application/json`.

APIs that return `application/hal+json` (or other `+json` types) never match that check. The body stays a string, and `sanitizeResponseBody()` falls through to `HTML Response`, so the real payload is missing in Telescope.

## What changed

- Treat `+json` content types (for example `application/hal+json`, `application/vnd.api+json`) as JSON in `formatBody()`
- Decode JSON object/array bodies in `sanitizeResponseBody()` the same way Telescope's `ClientRequestWatcher` does, even when the content type is not exact `application/json`
- Add Pest coverage for `hal+json`, charset variants, JSON:API, redaction, and the HTML negative case

HTML and other non-JSON bodies still show as `HTML Response`.